### PR TITLE
Fixes on SDPInstall and SCDPBundleInstall

### DIFF
--- a/functions/invoke-d365scdpbundleinstall.ps1
+++ b/functions/invoke-d365scdpbundleinstall.ps1
@@ -111,7 +111,7 @@ function Invoke-D365SCDPBundleInstall {
             $stopwatch = [Diagnostics.StopWatch]::StartNew();
             $bundleRoot = "$env:localappdata\temp\SCDPBundleInstall"
             
-            $bundleTotalCount = (Get-ChildItem "$bundleRoot\*.axscdp").Count
+            $bundleTotalCount = (Get-ChildItem "$bundleRoot\*.axscdp" -ErrorAction SilentlyContinue).Count
             $bundleCounter = 0
             
             while ($keepLooking -and $stopwatch.elapsed -lt $timeout)
@@ -131,7 +131,7 @@ function Invoke-D365SCDPBundleInstall {
                         {
                             $announcedBundle = $currentBundle
                             $bundleCounter = $bundleCounter + 1
-                            Write-PSFMessage -Level Verbose -Message "$bundleCounter/$bundleTotalCount : Processing hotfix package $announcedBundle [$(Get-Date)]"                            
+                            Write-PSFMessage -Level Verbose -Message "$bundleCounter/$bundleTotalCount : Processing hotfix package $announcedBundle"                            
                         }
                     }
                 }

--- a/functions/invoke-d365scdpbundleinstall.ps1
+++ b/functions/invoke-d365scdpbundleinstall.ps1
@@ -55,7 +55,10 @@ function Invoke-D365SCDPBundleInstall {
         [string] $TfsUri = "$Script:TfsUri",
 
         [Parameter(Mandatory = $false, Position = 4 )]
-        [switch] $ShowModifiedFiles
+        [switch] $ShowModifiedFiles,
+
+        [Parameter(Mandatory = $false, Position = 5 )]
+        [switch] $ShowProgress
 
     )
     
@@ -95,8 +98,50 @@ function Invoke-D365SCDPBundleInstall {
                             "-tfsprojecturi=`"$TfsUri`"")
     }
 
-    Write-PSFMessage -Level Verbose -Message "Invoking SCDPBundleInstall.exe" -Target $param
-    Start-Process -FilePath $executable -ArgumentList $param -NoNewWindow -Wait
+    Write-PSFMessage -Level Verbose -Message "Invoking SCDPBundleInstall.exe" -Target $param    
+    
+    if ($ShowProgress.IsPresent) {
+        
+        $process = Start-Process -FilePath $executable -ArgumentList $param -PassThru
+
+        while (!$process.HasExited) {
+            
+            $keepLooking = $true
+            $timeout = New-TimeSpan -Days 1
+            $stopwatch = [Diagnostics.StopWatch]::StartNew();
+            $bundleRoot = "$env:localappdata\temp\SCDPBundleInstall"
+            
+            $bundleTotalCount = (Get-ChildItem "$bundleRoot\*.axscdp").Count
+            $bundleCounter = 0
+            
+            while ($keepLooking -and $stopwatch.elapsed -lt $timeout)
+            {    
+                if(!(Test-Path -Path $bundleRoot)){
+                    $keepLooking = $false
+                }
+                else
+                {
+                    $currentBundleFolder = Get-ChildItem $bundleRoot -Directory
+            
+                    if ($currentBundleFolder)
+                    {
+                        $currentBundle = $currentBundleFolder.Name
+            
+                        if ($announcedBundle -ne $currentBundle)
+                        {
+                            $announcedBundle = $currentBundle
+                            $bundleCounter = $bundleCounter + 1
+                            Write-PSFMessage -Level Verbose -Message "$bundleCounter/$bundleTotalCount : Processing hotfix package $announcedBundle [$(Get-Date)]"                            
+                        }
+                    }
+                }
+                Start-Sleep -Seconds 1
+            } 
+        }         
+    }
+    else {
+        Start-Process -FilePath $executable -ArgumentList $param -NoNewWindow -Wait
+    }
     
     if ($ShowModifiedFiles.IsPresent) {
         $res = Get-ChildItem -Path $MetaDataDir -Recurse | Where-Object {$_.LastWriteTime -gt $StartTime}

--- a/functions/invoke-d365scdpbundleinstall.ps1
+++ b/functions/invoke-d365scdpbundleinstall.ps1
@@ -66,6 +66,8 @@ function Invoke-D365SCDPBundleInstall {
     if (!(Test-PathExists -Path $Path,$executable -Type Leaf)) {return}
     if (!(Test-PathExists -Path $MetaDataDir -Type Container)) {return}
     
+    Unblock-File -Path $Path #File is typically downloaded and extracted
+
     if ($InstallOnly.IsPresent) {
         $param = @("-install", 
         "-packagepath=$Path", 

--- a/functions/invoke-d365scdpbundleinstall.ps1
+++ b/functions/invoke-d365scdpbundleinstall.ps1
@@ -76,7 +76,7 @@ function Invoke-D365SCDPBundleInstall {
     else{
 
         if ($TfsUri -eq ""){
-            Write-PSFMessage -Level Host -Message "No TFS URI provided. Unable to complete the command"
+            Write-PSFMessage -Level Host -Message "No TFS URI provided. Unable to complete the command."
             Stop-PSFFunction -Message "Stopping because missing TFS URI parameter."
             return
         }

--- a/functions/invoke-d365scdpbundleinstall.ps1
+++ b/functions/invoke-d365scdpbundleinstall.ps1
@@ -74,6 +74,13 @@ function Invoke-D365SCDPBundleInstall {
         "-metadatastorepath=$MetaDataDir")
     }
     else{
+
+        if ($TfsUri -eq ""){
+            Write-PSFMessage -Level Host -Message "No TFS URI provided. Unable to complete the command"
+            Stop-PSFFunction -Message "Stopping because missing TFS URI parameter."
+            return
+        }
+
         switch($Command){
             "Prepare" {
                 $param = @("-prepare")

--- a/functions/invoke-d365sdpinstall.ps1
+++ b/functions/invoke-d365sdpinstall.ps1
@@ -123,9 +123,8 @@ function Invoke-D365SDPInstall {
                     "-runbookFile=`"$runbookFile`""
                 )
                 & $Util generate $param
-                & $Util execute "-runbookId=$runbookId"
                 & $Util import "-runbookfile=`"$runbookFile`""
-                & $Util execute "-runbookId=$runbookId"
+                & $Util execute "-runbookId=`"$runbookId`""
             }
             Write-PSFMessage -Level Verbose "All manual steps complete."
         }


### PR DESCRIPTION
- Unblock on downloaded file
- Check for TfsUri
- Fix order of operations when doing a "RunAll" command for SDPInstall