### PR TITLE
Start and Stop Environment when (de)activating maintenance mode

### DIFF
--- a/d365fo.tools/functions/disable-d365maintenancemode.ps1
+++ b/d365fo.tools/functions/disable-d365maintenancemode.ps1
@@ -108,6 +108,10 @@ function Disable-D365MaintenanceMode {
             "-setupmode", "maintenancemode",
             "-isinmaintenancemode", "false")
 
+        Stop-D365Environment -All
+
         Start-Process -FilePath $executable -ArgumentList ($params -join " ") -NoNewWindow -Wait
+
+        Start-D365Environment -All
     }
 }

--- a/d365fo.tools/functions/enable-d365maintenancemode.ps1
+++ b/d365fo.tools/functions/enable-d365maintenancemode.ps1
@@ -89,7 +89,7 @@ function Enable-D365MaintenanceMode {
 
         Invoke-D365SqlScript @Params -FilePath $("$script:PSModuleRoot\internal\sql\enable-maintenancemode.sql") -TrustedConnection $UseTrustedConnection
 
-        Start-D365Environment -All
+        Start-D365Environment -Aos
     }
     else {
 
@@ -108,6 +108,10 @@ function Enable-D365MaintenanceMode {
             "-setupmode", "maintenancemode",
             "-isinmaintenancemode", "true")
 
+        Stop-D365Environment -All
+
         Start-Process -FilePath $executable -ArgumentList ($params -join " ") -NoNewWindow -Wait
+
+        Start-D365Environment -Aos
     }
 }


### PR DESCRIPTION
- Start and Stop Environment when (de)activating maintenance mode while running in admin mode
- only start AOS after enabling maintenance mode; batch won't start anyway and also DMF and MMR should not run in maintenance mode