### PR TITLE
Fixed a couple of typos in the import-aaduserintod365fo internal function

### DIFF
--- a/d365fo.tools/internal/functions/import-aaduserIntod365fo.ps1
+++ b/d365fo.tools/internal/functions/import-aaduserIntod365fo.ps1
@@ -87,7 +87,7 @@ function Import-AadUserIntoD365FO {
 
                 $securityAdded = Add-AadUserSecurity $sqlCommand $Id
 
-                Write-PSFMessage -Level Host -Message "User $SignInName Importet"
+                Write-PSFMessage -Level Host -Message "User $SignInName Imported"
 
                 if ($securityAdded -eq $false) {
                     Write-PSFMessage -Level Host -Message "User $SignInName did not get securityRoles"

--- a/d365fo.tools/internal/functions/import-aaduserIntod365fo.ps1
+++ b/d365fo.tools/internal/functions/import-aaduserIntod365fo.ps1
@@ -102,7 +102,7 @@ function Import-AadUserIntoD365FO {
             }
         }
         else {
-            Write-PSFMessage -Level Host -Message "An User with ID = '$ID' allready exists"
+            Write-PSFMessage -Level Host -Message "An User with ID = '$ID' already exists"
             #Stop-PSFFunction -Message "Stopping because of errors" -StepsUpward 1
             #return
         }


### PR DESCRIPTION
I noticed there were a couple of typos in the import-aaduserintod365fo internal function where messages were output to the console. I have fixed these typos. This is to fix issue #174