### PR TITLE
Switch-D365ActiveDatabase: move mandatory param NewDatabaseName at first

### DIFF
--- a/d365fo.tools/functions/switch-d365activedatabase.ps1
+++ b/d365fo.tools/functions/switch-d365activedatabase.ps1
@@ -38,20 +38,21 @@
 function Switch-D365ActiveDatabase {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $false, Position = 1)]
-        [string]$DatabaseServer = $Script:DatabaseServer,
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$NewDatabaseName,
 
         [Parameter(Mandatory = $false, Position = 2)]
-        [string]$DatabaseName = $Script:DatabaseName,
+        [string]$DatabaseServer = $Script:DatabaseServer,
 
         [Parameter(Mandatory = $false, Position = 3)]
-        [string]$SqlUser = $Script:DatabaseUserName,
+        [string]$DatabaseName = $Script:DatabaseName,
 
         [Parameter(Mandatory = $false, Position = 4)]
-        [string]$SqlPwd = $Script:DatabaseUserPassword,
+        [string]$SqlUser = $Script:DatabaseUserName,
+
+        [Parameter(Mandatory = $false, Position = 5)]
+        [string]$SqlPwd = $Script:DatabaseUserPassword
         
-        [Parameter(Mandatory = $true, Position = 5)]
-        [string]$NewDatabaseName
     )
 
     $UseTrustedConnection = Test-TrustedConnection $PSBoundParameters


### PR DESCRIPTION
See issue 193.
Moving NewDatabaseName parameter as the first one as it's the only mandatory parameter.
This will allow to run directly the cmdlet like: 'Switch-D365ActiveDatabase AxDB_imported' when using it with the command line.