### PR TITLE
Making Set-D365Admin function work with PU29 and higher

### DIFF
--- a/d365fo.tools/internal/functions/set-adminuser.ps1
+++ b/d365fo.tools/internal/functions/set-adminuser.ps1
@@ -64,7 +64,16 @@ function Set-AdminUser {
     
     Write-PSFMessage -Level Verbose -Message "MetaDataDirectory: $MetaDataNodeDirectory" -Target $MetaDataNodeDirectory
 
-    $AdminFile = "$MetaDataNodeDirectory\Bin\AdminUserProvisioning.exe"
+    $AdminFileLocationPu29AndUp  = "$MetaDataNodeDirectory\Bin\Microsoft.Dynamics.AdminUserProvisioningLib.dll"
+    $AdminFileLocationBeforePu29 = "$MetaDataNodeDirectory\Bin\AdminUserProvisioning.exe"
+    if ( Test-Path -Path $AdminFileLocationPu29AndUp -PathType Leaf ) {
+        $AdminFile = $AdminFileLocationPu29AndUp
+        $AdminLibNameSpace = "Microsoft.Dynamics.AdminUserProvisioningLib"
+    } else {
+        $AdminFile = $AdminFileLocationBeforePu29
+        $AdminLibNameSpace = "Microsoft.Dynamics.AdminUserProvisioning"
+    }
+    Write-PSFMessage -Level Verbose -Message "Path to AdminFile: $AdminFile"
 
     $TempFileName = New-TemporaryFile
     $TempFileName = $TempFileName.BaseName
@@ -75,7 +84,7 @@ function Set-AdminUser {
 
     $adminAssembly = [System.Reflection.Assembly]::LoadFile($AdminDll)
 
-    $AdminUserUpdater = $adminAssembly.GetType("Microsoft.Dynamics.AdminUserProvisioning.AdminUserUpdater")
+    $AdminUserUpdater = $adminAssembly.GetType("$AdminLibNameSpace.AdminUserUpdater")
 
     $PublicBinding = [System.Reflection.BindingFlags]::Public
     $StaticBinding = [System.Reflection.BindingFlags]::Static
@@ -83,18 +92,23 @@ function Set-AdminUser {
 
     $UpdateAdminUser = $AdminUserUpdater.GetMethod("UpdateAdminUser", $CombinedBinding)
     
-    Write-PSFMessage -Level Verbose -Message "Testing for PU26 or higher"
-    if((($UpdateAdminUser.GetParameters()).Name) -contains "providerName") {
-        Write-PSFMessage -Level Verbose -Message "PU26 or higher found. Will adjust parameters."
+    Write-PSFMessage -Level Verbose -Message "Adjusting parameter set to the PU that is in use in this environment."
+    if((($UpdateAdminUser.GetParameters()).Name) -contains "hostUrl") {
+        Write-PSFMessage -Level Verbose -Message "PU29 or higher found. Will adjust parameters."
+        $params = $SignInName, "AAD-Global", $null, $null, $DatabaseServer, $DatabaseName, $SqlUser, $SqlPwd, "$Script:AOSPath\", $Script:Url
+    }
+    elseif((($UpdateAdminUser.GetParameters()).Name) -contains "providerName") {
+        Write-PSFMessage -Level Verbose -Message "PU26/27/28 found. Will adjust parameters."
         $params = $SignInName, "AAD-Global", $null, $null, $DatabaseServer, $DatabaseName, $SqlUser, $SqlPwd
     }
     else {
-        Write-PSFMessage -Level Verbose -Message "Lower PU found. Will adjust parameters."
+        Write-PSFMessage -Level Verbose -Message "PU below PU26 found. Will adjust parameters."
         $params = $SignInName, $null, $null, $DatabaseServer, $DatabaseName, $SqlUser, $SqlPwd
     }
 
     try {
-        Write-PSFMessage -Level Verbose -Message "Updating Admin using the values $SignInName, $DatabaseServer, $DatabaseName, $SqlUser, $SqlPwd"
+	    $paramsString = $params -join ", "
+        Write-PSFMessage -Level Verbose -Message "Updating Admin using the values $paramsString"
         $UpdateAdminUser.Invoke($null, $params)
     }
     catch {


### PR DESCRIPTION
Addresses two issues with PU29 and higher: 
1. Two new parameters have been added to Microsoft's UpdateAdminUser function,
2. MS has restructured its code and moved the UpdateAdminUser function from the exe to its own dll)
The change is backward compatible, so the function should still be functional on older environments (PU28 and below).
As discussed in #272 .