### PR TITLE
Update new-d365isvlicense.ps1

### DIFF
--- a/d365fo.tools/functions/new-d365isvlicense.ps1
+++ b/d365fo.tools/functions/new-d365isvlicense.ps1
@@ -67,9 +67,16 @@ function New-D365ISVLicense {
         Expand-Archive -Path $Path -DestinationPath $packageTemp
 
         $licenseMergePath = Join-Path $packageTemp "AosService\Scripts\License"
-
-        Get-ChildItem -Path $licenseMergePath | Remove-Item -Force -ErrorAction SilentlyContinue
-
+		
+		if (Test-Path -Path $licenseMergePath) 
+		{
+			Get-ChildItem -Path $licenseMergePath | Remove-Item -Force -ErrorAction SilentlyContinue
+		}
+		else
+		{
+			$null = New-Item -Path $licenseMergePath -ItemType Directory -ErrorAction SilentlyContinue
+		}
+		
         Write-PSFMessage -Level Verbose -Message "Copying the license file into place."
         Copy-Item -Path $LicenseFile -Destination $licenseMergePath
 


### PR DESCRIPTION
The indentation looks wierd here, it looked ok in comapare. 
The code makes sure if the given path (folder) does not exist, it will create it, thus it's the first time importing a license into a package it will not fail.