### PR TITLE
Invoke-D365ModuleCompile: Add -xref option

### DIFF
--- a/d365fo.tools/functions/invoke-d365modulecompile.ps1
+++ b/d365fo.tools/functions/invoke-d365modulecompile.ps1
@@ -120,6 +120,7 @@ function Invoke-D365ModuleCompile {
             "-referencefolder=`"$ReferenceDir`"",
             "-log=`"$logFile`"",
             "-xmlLog=`"$logXmlFile`"",
+            "-xref",
             "-verbose"
         )
 


### PR DESCRIPTION
Add the -xref option to Invoke-D365ModuleCompile to enable the creation of cross references during compilation