### PR TITLE
Update Start Stop environment API notes

### DIFF
--- a/d365fo.tools/functions/invoke-d365lcsenvironmentstart.ps1
+++ b/d365fo.tools/functions/invoke-d365lcsenvironmentstart.ps1
@@ -4,7 +4,7 @@
         Start a specified environment through LCS.
         
     .DESCRIPTION
-        Start a specified IAAS environment that is Microsoft managed or customer managed through the LCS API.
+        Start a specified IAAS environment that is Customer Managed through the LCS API.
         
     .PARAMETER ProjectId
         The project id for the Dynamics 365 for Finance & Operations project inside LCS
@@ -65,11 +65,13 @@
         Invoke-D365LcsEnvironmentStop
         
     .NOTES
-        Only IAAS (Customer managed and Microsoft managed) are supported with this API. Self-service environments do not have a start functionality and will not work with this API.
-        
+        Only Customer Managed IAAS environments are supported with this API.
+        Microsoft Managed IAAS environments need to remain online to allow for Microsoft update operations and are not supported with this API.
+        Self-service environments do not have a stop functionality and will not work with this API.
+
         Tags: Environment, Start, StartStop, Stop, LCS, Api
         
-        Author: Billy Richardson (@richardsondev)
+        Author: Mötz Jensen (@Splaxi), Billy Richardson (@richardsondev)
         
 #>
 

--- a/d365fo.tools/functions/invoke-d365lcsenvironmentstop.ps1
+++ b/d365fo.tools/functions/invoke-d365lcsenvironmentstop.ps1
@@ -4,7 +4,7 @@
         Stop a specified environment through LCS.
         
     .DESCRIPTION
-        Stop a specified IAAS environment that is Microsoft managed or customer managed through the LCS API.
+        Stop a specified IAAS environment that is Customer Managed through the LCS API.
         
     .PARAMETER ProjectId
         The project id for the Dynamics 365 for Finance & Operations project inside LCS
@@ -65,11 +65,13 @@
         Invoke-D365LcsEnvironmentStart
         
     .NOTES
-        Only IAAS (Customer managed and Microsoft managed) are supported with this API. Self-service environments do not have a stop functionality and will not work with this API.
+        Only Customer Managed IAAS environments are supported with this API.
+        Microsoft Managed IAAS environments need to remain online to allow for Microsoft update operations and are not supported with this API.
+        Self-service environments do not have a stop functionality and will not work with this API.
         
         Tags: Environment, Stop, StartStop, Start, LCS, Api
         
-        Author: Billy Richardson (@richardsondev)
+        Author: Mötz Jensen (@Splaxi), Billy Richardson (@richardsondev)
         
 #>
 

--- a/d365fo.tools/internal/functions/start-lcsenvironmentstartstop.ps1
+++ b/d365fo.tools/internal/functions/start-lcsenvironmentstartstop.ps1
@@ -4,7 +4,7 @@
         Start or stop a given environment using LCS
         
     .DESCRIPTION
-        Start or stop a specified IAAS environment that is Microsoft managed or customer managed through the LCS API.
+        Start or stop a specified IAAS environment that is Customer Managed through the LCS API.
         
     .PARAMETER BearerToken
         The token you want to use when working against the LCS api
@@ -58,7 +58,7 @@
     .NOTES
         Tags: Environment, Stop, Start, LCS, Api, AAD, Token
         
-        Author: Billy Richardson (@richardsondev)
+        Author: Mötz Jensen (@Splaxi), Billy Richardson (@richardsondev)
 #>
 
 function Start-LcsEnvironmentStartStop {


### PR DESCRIPTION
There is an update going out to the LCS backend API this week to disallow the Start and Stop API endpoints from working with Microsoft Managed environments. This PR is to update the documentation notes for the D365FO.tools methods that use the backend APIs.

Microsoft Managed environments are required to be online for Microsoft infrastructure and application updates. Since the cost for these environments running are on Microsoft, there is no cost savings for customers by stopping these environments through the API. 

If we have enough demand, we can enable Sandbox Microsoft Managed support. For now, the restriction for all Microsoft Managed environments is now in place.

In addition, updating the author property to correctly include Mötz for writing the base structure for this method.