### PR TITLE
Invoke-D365DbSyncPartial: make SyncList parameter optional

### DIFF
--- a/d365fo.tools/functions/invoke-d365dbsyncpartial.ps1
+++ b/d365fo.tools/functions/invoke-d365dbsyncpartial.ps1
@@ -103,7 +103,6 @@
 function Invoke-D365DbSyncPartial {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
         [string[]] $SyncList,
 
         [string[]] $SyncExtensionsList,

--- a/d365fo.tools/internal/functions/get-syncelements.ps1
+++ b/d365fo.tools/internal/functions/get-syncelements.ps1
@@ -77,7 +77,7 @@ function Get-SyncElements {
             $null = $baseSyncElements.Add($extElement.Substring(0, $extElement.IndexOf('.')))
         }
 
-        Write-PSFMessage -Level Debug -Message "Elements from $ModuleName retrieved: $(($baseSyncElements + $extensionToBaseSyncElements) -join ",")"
+        Write-PSFMessage -Level Debug -Message "Elements from $ModuleName retrieved: $(($baseSyncElements + $extensionSyncElements) -join ",")"
 
         [PSCustomObject]@{
             BaseSyncElements = $baseSyncElements.ToArray();

--- a/d365fo.tools/tests/functions/Invoke-D365DBSyncPartial.Tests.ps1
+++ b/d365fo.tools/tests/functions/Invoke-D365DBSyncPartial.Tests.ps1
@@ -18,7 +18,7 @@
 			$parameter.IsDynamic | Should -Be $False
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False


### PR DESCRIPTION
By making the SyncList parameter optional, the partial database sync can also be executed for modules that only have extensions of synchronizable objects (e.g. only table extensions).

#515 