### PR TITLE
Import-AssemblyFileIntoMemory: Copy  the shadow file to temp folder

### DIFF
--- a/d365fo.tools/internal/functions/import-assemblyfileintomemory.ps1
+++ b/d365fo.tools/internal/functions/import-assemblyfileintomemory.ps1
@@ -14,7 +14,7 @@
     .EXAMPLE
         PS C:\> Import-AssemblyFileIntoMemory -Path "C:\AOSService\PackagesLocalDirectory\Bin\Microsoft.Dynamics.BusinessPlatform.ProductInformation.Framework.dll"
         
-        This will create an new file named "C:\AOSService\PackagesLocalDirectory\Bin\Microsoft.Dynamics.BusinessPlatform.ProductInformation.Framework.dll_shawdow.dll"
+        This will create an new file named "Microsoft.Dynamics.BusinessPlatform.ProductInformation.Framework.dll_shawdow.dll" in the temp folder
         The new file is then imported into memory using .NET Reflection.
         After the file has been imported, it will be deleted from disk.
         
@@ -38,7 +38,8 @@ function Import-AssemblyFileIntoMemory {
 
     foreach ($itemPath in $Path) {
 
-        $shadowClonePath = "$itemPath`_shadow.dll"
+        $filename = Split-Path -Path $itemPath -Leaf
+        $shadowClonePath = Join-Path $env:TEMP "$filename`_shadow.dll"
 
         try {
             Write-PSFMessage -Level Debug -Message "Cloning $itemPath to $shadowClonePath"


### PR DESCRIPTION
There is an issue that the IIS is being reset, whenever the tools module is loaded. At least refreshing the browser of a currently responsive sessions takes the usual time after an IIS restart, when you open a PowerShell session and call one of the Tool's CmdLets.
I was able to narrow it down to the Get-ApplicationEnvironment function and specifically the Import-AssemblyFileIntoMemory that is called from there.
It seems that the IIS restarts, whenever a file is added or deleted in the webroot\bin folder. By creating the shadow files in the temp folder you can prevent that.
If you don't like $env:TEMP you can also go for C:\Temp\d365fo.tools or whatever you think suits best 😄 