### PR TITLE
fix some wiki links and improve wiki publishing

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish wiki folder to repository wiki
-        uses: OrlovM/Wiki-Action@v1
+        uses: FH-Inway/github-wiki-publish-action
         with:
           path: "wiki"
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+        env:
+          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish wiki folder to repository wiki
-        uses: FH-Inway/github-wiki-publish-action
+        uses: FH-Inway/github-wiki-publish-action@v1
         with:
           path: "wiki"
         env:

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -18,10 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Additional steps to generate documentation in "Documentation" directory
       - name: Publish wiki folder to repository wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@v1
+        uses: OrlovM/Wiki-Action@v1
         with:
           path: "wiki"
-        env:
-          GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish wiki folder to repository wiki
-        uses: FH-Inway/github-wiki-publish-action@v1
+        uses: SwiftDocOrg/github-wiki-publish-action@rsync
         with:
-          path: "wiki"
+          path: "wiki/"
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/wiki/How-To-Import-Bacpac-Into-Tier1.md
+++ b/wiki/How-To-Import-Bacpac-Into-Tier1.md
@@ -67,4 +67,4 @@ Start-D365Environment -All
 [[images/howtos/Start-Services.gif]]
 
 ## **Closing comments**
-In this how to we showed you how you can update a Tier1 environment with a bacpac file, and how to make sure that the database is synchronized with the codebase. Depending on where you obtained the bacpac file from, you might need to [update](How-To-Update-Users-In-Db) and/or [enable](How-To-Enable-Users-In-Db.md) the users. Please refer to the How To section and learn how to complete either task.
+In this how to we showed you how you can update a Tier1 environment with a bacpac file, and how to make sure that the database is synchronized with the codebase. Depending on where you obtained the bacpac file from, you might need to [update](How-To-Update-Users-In-Db) and/or [enable](How-To-Enable-Users-In-Db) the users. Please refer to the How To section and learn how to complete either task.

--- a/wiki/How-To-Import-Bacpac-Into-Tier1.md
+++ b/wiki/How-To-Import-Bacpac-Into-Tier1.md
@@ -64,7 +64,7 @@ With the synchronization of the database completed, we need to start all D365FO 
 Start-D365Environment -All
 ```
 
-[[images/howtos/Start-Services.gif]]
+[[/images/howtos/Start-Services.gif]]
 
 ## **Closing comments**
 In this how to we showed you how you can update a Tier1 environment with a bacpac file, and how to make sure that the database is synchronized with the codebase. Depending on where you obtained the bacpac file from, you might need to [update](How-To-Update-Users-In-Db) and/or [enable](How-To-Enable-Users-In-Db) the users. Please refer to the How To section and learn how to complete either task.

--- a/wiki/How-To-Import-Bacpac-Into-Tier1.md
+++ b/wiki/How-To-Import-Bacpac-Into-Tier1.md
@@ -67,4 +67,4 @@ Start-D365Environment -All
 [[images/howtos/Start-Services.gif]]
 
 ## **Closing comments**
-In this how to we showed you how you can update a Tier1 environment with a bacpac file, and how to make sure that the database is synchronized with the codebase. Depending on where you obtained the bacpac file from, you might need to [update](How-To-Update-Users-In-Db.md) and/or [enable](How-To-Enable-Users-In-Db.md) the users. Please refer to the How To section and learn how to complete either task.
+In this how to we showed you how you can update a Tier1 environment with a bacpac file, and how to make sure that the database is synchronized with the codebase. Depending on where you obtained the bacpac file from, you might need to [update](How-To-Update-Users-In-Db) and/or [enable](How-To-Enable-Users-In-Db.md) the users. Please refer to the How To section and learn how to complete either task.


### PR DESCRIPTION
Turns out that the [Publish to GitHub Wiki](https://github.com/SwiftDocOrg/github-wiki-publish-action) GitHub action only publishes .md files to the wiki repository. I changed the action to a work in progress branch to include all files that are in the wiki folder.

The commits are a bit messy. I first started with a clean up of some broken links. When I published this, I noticed that in my wiki, the images were missing. I first tried another GitHub action, which included the images but had other issues. Then I modified the original GitHub action to have it include all files, only to realize that the repo of the GitHub action already has a work in progress branch that solves that issue.