### PR TITLE
✨ Added cmdlets  to manage web server type

### DIFF
--- a/d365fo.tools/d365fo.tools.psd1
+++ b/d365fo.tools/d365fo.tools.psd1
@@ -163,6 +163,7 @@
 		'Get-D365UserAuthenticationDetail',
 
 		'Get-D365VisualStudioCompilerResult',
+		'Get-D365WebServerType',
 		'Get-D365WindowsActivationStatus',
 
 		'Import-D365AadUser',
@@ -289,6 +290,7 @@
 		'Set-D365SysAdmin',
 
 		'Set-D365WebConfigDatabase',
+		'Set-D365WebServerType',
 
 		'Set-D365TraceParserFileSize',
 

--- a/d365fo.tools/functions/get-d365webservertype.ps1
+++ b/d365fo.tools/functions/get-d365webservertype.ps1
@@ -1,0 +1,38 @@
+
+<#
+    .SYNOPSIS
+        Get the default web server to be used
+        
+    .DESCRIPTION
+        Get the web server which will be used to run D365FO: Either IIS or IIS Express.
+        Newly deployed development machines will have this set to IIS Express by default.
+
+    .EXAMPLE
+        PS C:\> Get-D365WebServerType
+        
+        This will display the current web server type registered in the "DynamicsDevConfig.xml" file.
+        Located in "K:\AosService\PackagesLocalDirectory\bin".
+        
+    .NOTES
+        Tag: Web Server, IIS, IIS Express, Development
+        
+        Author: Sander Holvoet (@smholvoet)
+   
+#>
+
+function Get-D365WebServerType {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    [CmdletBinding()]
+    param ()
+
+    $filePath = "K:\AosService\PackagesLocalDirectory\bin\DynamicsDevConfig.xml"
+    if (-not (Test-PathExists -Path $filePath -Type Leaf)) { return }
+
+    if (Test-PSFFunctionInterrupt) { return }
+
+    $namespace = @{ns = "http://schemas.microsoft.com/dynamics/2012/03/development/configuration" }
+    $runtimeHostType = Select-Xml -XPath "/ns:DynamicsDevConfig/ns:RuntimeHostType" -Path $filePath -Namespace $namespace
+
+    $runtimeHostTypeValue = $runtimeHostType.Node.InnerText
+    [PSCustomObject] @{RuntimeHostType = $runtimeHostTypeValue }
+}

--- a/d365fo.tools/functions/set-d365webservertype.ps1
+++ b/d365fo.tools/functions/set-d365webservertype.ps1
@@ -1,0 +1,72 @@
+
+<#
+    .SYNOPSIS
+        Set the web server type to be used to run the D365FO instance
+        
+    .DESCRIPTION
+        Set the web server which will be used to run D365FO: Either IIS or IIS Express.
+        Newly deployed development machines will have this set to IIS Express by default.
+
+        It will backup the current "DynamicsDevConfig.xml" file, for you to revert the changes if anything should go wrong.
+        
+    .PARAMETER RuntimeHostType
+        The type of web server you want to use.
+
+        Valid options are:
+        "IIS"
+        "IISExpress"
+        
+    .EXAMPLE
+        PS C:\> Set-D365WebServerType -RuntimeHostType "IIS"
+        
+        This will update the current web server type registered in the "DynamicsDevConfig.xml" file.
+        This file is located "K:\AosService\PackagesLocalDirectory\bin".
+        It will backup the current "DynamicsDevConfig.xml" file.
+        It will replace the value inside the "RuntimeHostType" tag.
+        
+    .NOTES
+        Tag: Web Server, IIS, IIS Express, Development
+        
+        Author: Sander Holvoet (@smholvoet)
+      
+#>
+
+function Set-D365WebServerType {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
+        [ValidateSet('IIS', 'IISExpress')]
+        [string] $RuntimeHostType
+    )
+
+    begin {
+        $filePath = "K:\AosService\PackagesLocalDirectory\bin\DynamicsDevConfig.xml"
+
+        if (-not (Test-PathExists -Path $filePath -Type Leaf)) { return }
+    }
+
+    process {
+        if (Test-PSFFunctionInterrupt) { return }
+
+        $filePathBackup = $filePath.Replace(".xml", ".xml$((Get-Date).Ticks)")
+        Copy-Item -Path $filePath -Destination $filePathBackup -Force
+
+        $namespace = @{ns = "http://schemas.microsoft.com/dynamics/2012/03/development/configuration" }
+
+        $xmlDoc = [xml] (Get-Content -Path $filePath)
+        $runtimeHostType = Select-Xml -Xml $xmlDoc -XPath "/ns:DynamicsDevConfig/ns:RuntimeHostType" -Namespace $namespace
+
+        $oldValue = $runtimeHostType.Node.InnerText
+
+        Write-PSFMessage -Level Verbose -Message "Old value found in the file was: $oldValue" -Target $oldValue
+
+        $runtimeHostType.Node.InnerText = $RuntimeHostType
+        $xmlDoc.Save($filePath)
+    }
+
+    end {
+        Get-D365WebServerType
+    }
+}

--- a/d365fo.tools/tests/functions/Get-D365WebServerType.Tests.ps1
+++ b/d365fo.tools/tests/functions/Get-D365WebServerType.Tests.ps1
@@ -1,0 +1,24 @@
+Describe "Get-D365WebServerType Unit Tests" -Tag "Unit" {
+	BeforeAll {
+		# Place here all things needed to prepare for the tests
+	}
+	AfterAll {
+		# Here is where all the cleanup tasks go
+	}
+	
+	Describe "Ensuring unchanged command signature" {
+		It "should have the expected parameter sets" {
+			(Get-Command Get-D365WebServerType).ParameterSets.Name | Should -Be '__AllParameterSets'
+		}
+		
+
+	}
+	
+	Describe "Testing parameterset __AllParameterSets" {
+		<#
+		__AllParameterSets -
+		__AllParameterSets -
+		#>
+	}
+
+}

--- a/d365fo.tools/tests/functions/Set-D365WebServerType.Tests.ps1
+++ b/d365fo.tools/tests/functions/Set-D365WebServerType.Tests.ps1
@@ -1,0 +1,36 @@
+Describe "Set-D365WebServerType Unit Tests" -Tag "Unit" {
+	BeforeAll {
+		# Place here all things needed to prepare for the tests
+	}
+	AfterAll {
+		# Here is where all the cleanup tasks go
+	}
+	
+	Describe "Ensuring unchanged command signature" {
+		It "should have the expected parameter sets" {
+			(Get-Command Set-D365WebServerType).ParameterSets.Name | Should -Be '__AllParameterSets'
+		}
+		
+		It 'Should have the expected parameter RumtimeHostType' {
+			$parameter = (Get-Command Set-D365WebServerType).Parameters['RumtimeHostType']
+			$parameter.Name | Should -Be 'RumtimeHostType'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+	}
+	
+	Describe "Testing parameterset __AllParameterSets" {
+		<#
+		__AllParameterSets -RumtimeHostType
+		__AllParameterSets -RumtimeHostType
+		#>
+	}
+
+}

--- a/docs/Get-D365WebServerType.md
+++ b/docs/Get-D365WebServerType.md
@@ -1,0 +1,47 @@
+---
+external help file: d365fo.tools-help.xml
+Module Name: d365fo.tools
+online version:
+schema: 2.0.0
+---
+
+# Get-D365WebServerType
+
+## SYNOPSIS
+Get the default web server to be used
+
+## SYNTAX
+
+```
+Get-D365WebServerType [<CommonParameters>]
+```
+
+## DESCRIPTION
+Get the web server which will be used to run D365FO: Either IIS or IIS Express.
+Newly deployed development machines will have this set to IIS Express by default.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-D365WebServerType
+```
+
+This will display the current web server type registered in the "DynamicsDevConfig.xml" file.
+Located in "K:\AosService\PackagesLocalDirectory\bin".
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Tag: Web Server, IIS, IIS Express, Development
+
+Author: Sander Holvoet (@smholvoet)
+
+## RELATED LINKS

--- a/docs/Set-D365WebServerType.md
+++ b/docs/Set-D365WebServerType.md
@@ -1,0 +1,70 @@
+---
+external help file: d365fo.tools-help.xml
+Module Name: d365fo.tools
+online version:
+schema: 2.0.0
+---
+
+# Set-D365WebServerType
+
+## SYNOPSIS
+Set the web server type to be used to run the D365FO instance
+
+## SYNTAX
+
+```
+Set-D365WebServerType [-RuntimeHostType] <String> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set the web server which will be used to run D365FO: Either IIS or IIS Express.
+Newly deployed development machines will have this set to IIS Express by default.
+
+It will backup the current "DynamicsDevConfig.xml" file, for you to revert the changes if anything should go wrong.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-D365WebServerType -RuntimeHostType "IIS"
+```
+
+This will update the current web server type registered in the "DynamicsDevConfig.xml" file.
+This file is located "K:\AosService\PackagesLocalDirectory\bin".
+It will backup the current "DynamicsDevConfig.xml" file.
+It will replace the value inside the "RuntimeHostType" tag.
+
+## PARAMETERS
+
+### -RuntimeHostType
+The type of web server you want to use.
+
+Valid options are:
+"IIS"
+"IISExpress"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Tag: Web Server, IIS, IIS Express, Development
+
+Author: Sander Holvoet (@smholvoet)
+
+## RELATED LINKS


### PR DESCRIPTION
Added `Get-D365WebServerType` and  `Set-D365WebServerType` cmdlets which allow you to quickly change the web server to either IIS or IIS Express.

Both cmdlets are nearly identical to the existing `Get-D365DefaultModelForNewProjects` / `Set-D365DefaultModelForNewProjects` cmdlets which also replace the value of a specific XML node. Only thing I'm not quite sure of is the location of the `DynamicsDevConfig.xml` file. It will currently look for this file in `K:\AosService\PackagesLocalDirectory\bin\`, which should be the default service drive for most dev boxes...

- 💪 Fixes d365collaborative/d365fo.tools#571.
- ✔ added documentation
- ✔ added tests


