### PR TITLE
Windows Defender Rules: Add xppc and LabelC executables

### DIFF
--- a/d365fo.tools/functions/add-d365windowsdefenderrules.ps1
+++ b/d365fo.tools/functions/add-d365windowsdefenderrules.ps1
@@ -66,6 +66,8 @@ function Add-D365WindowsDefenderRules {
         Add-MpPreference -ExclusionProcess "$Script:BinDir\xppcAgent.exe"
         Add-MpPreference -ExclusionProcess "$Script:BinDir\SyncEngine.exe"
         Add-MpPreference -ExclusionProcess "$AOSPath\Batch.exe"
+        Add-MpPreference -ExclusionProcess "$AOSPath\xppc.exe"
+        Add-MpPreference -ExclusionProcess "$AOSPath\LabelC.exe"
         # add SQLServer
         Add-MpPreference -ExclusionProcess "C:\Program Files\Microsoft SQL Server\130\LocalDB\Binn\sqlservr.exe"
         Add-MpPreference -ExclusionProcess "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\Binn\sqlservr.exe"


### PR DESCRIPTION
After checking a strange CPU spike in latest PU versions during build & sync process started from VS, we found out these two executables need to be added to the list of exclusions too.