### PR TITLE
Change Import-D365AadUser added UserPrincipalName to support UserPrincipalName #611

### DIFF
--- a/d365fo.tools/functions/import-d365aaduser.ps1
+++ b/d365fo.tools/functions/import-d365aaduser.ps1
@@ -41,7 +41,7 @@
         
     .PARAMETER IdValue
         Specify which field to use as ID value when importing the users.
-        Available options 'Login' / 'FirstName'
+        Available options 'Login' / 'FirstName' / 'UserPrincipalName'
         
         Default is 'Login'
         
@@ -147,7 +147,7 @@ function Import-D365AadUser {
         [string] $NameSuffix = "",
 
         [Parameter(Mandatory = $false, Position = 9)]
-        [ValidateSet('Login', 'FirstName')]
+        [ValidateSet('Login', 'FirstName', 'UserPrincipalName')]
         [string] $IdValue = "Login",
 
         [Parameter(Mandatory = $false, Position = 10)]
@@ -304,6 +304,9 @@ function Import-D365AadUser {
             $id = ""
             if ($IdValue -eq 'Login') {
                 $id = $IdPrefix + $(Get-LoginFromEmail $user.Mail)
+            }
+            elseif($IdValue -eq 'UserPrincipalName') {
+                $id = $IdPrefix + $user.UserPrincipalName
             }
             else {
                 $id = $IdPrefix + $user.GivenName


### PR DESCRIPTION
Adding functionality to be able to use the UserPrincipalName in de AAD as the IDValue for Import-D365AadUser.

Some companies have multiple domains resistered to their AAD and the emailaddress of user is not equal to the actual loginname that is used in the AAD, therefore when using the 'Login' ad IdValue in Import-D365AadUser will cause the user to be unable to login the D365 environment.