### PR TITLE
:memo: enable dependency graph

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,10 @@
+# Used to define the dependencies of the d365fo.tools PowerShell module
+# in a way that can be evaluated for the GitHub dependency graph.
+# See https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph
+name: Dependencies
+
+jobs:
+  dependencies:
+    steps:
+      - name: PSFramework
+        uses: PowershellFrameworkCollective/psframework@32c18f13173be8cc6b6803c63c40b9d7ab5aec12

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,10 +1,22 @@
 # Used to define the dependencies of the d365fo.tools PowerShell module
 # in a way that can be evaluated for the GitHub dependency graph.
 # See https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph
+# The actual dependencies are defined in https://github.com/d365collaborative/d365fo.tools/blob/master/d365fo.tools/d365fo.tools.psd1
 name: Dependencies
 
 jobs:
   dependencies:
     steps:
       - name: PSFramework
-        uses: PowershellFrameworkCollective/psframework@32c18f13173be8cc6b6803c63c40b9d7ab5aec12
+        uses: PowershellFrameworkCollective/psframework@32c18f13173be8cc6b6803c63c40b9d7ab5aec12 # version 1.0.12
+      - name: Azure.Storage
+        uses: Azure/azure-powershell@v4.4.0-September2017 # unclear which commit/tag corresponds to https://www.powershellgallery.com/packages/Azure.Storage/4.4.0
+      # AzureAd does not seem to have a public GitHub repository
+      # - name: AzureAd
+      #   uses: 
+      - name: PSNotification
+        uses: Splaxi/PSNotification@b344c3dfdb04db1a338f203d1a0c5ae72d67ae89 # version 0.5.3
+      - name: PSOAuthHelper
+        uses: Splaxi/PSOAuthHelper@837a2da63bf76e86f339a4e43e38df5a3b82affe # version 0.3.0
+      - name: ImportExcel
+        uses: dfinke/ImportExcel@v7.1.0

--- a/README.md
+++ b/README.md
@@ -1,38 +1,41 @@
 ﻿# **d365fo.tools**
+
 PowerShell module to handle the different management tasks during a Dynamics 365 Finance & Operations (D365FO)
 Read more about D365FO on [docs.microsoft.com](https://docs.microsoft.com/en-us/dynamics365/unified-operations/fin-and-ops/index)
 
 Available on PowerShell Gallery
 [d365fo.tools](https://www.powershellgallery.com/packages/d365fo.tools)
 
-## **Getting started**
-### **Install the latest module**
+[[_TOC_]]
+
+## Getting started
+### Install the latest module
 ```
 Install-Module -Name d365fo.tools
 ```
 
-### **Install without administrator privileges**
+### Install without administrator privileges
 ```
 Install-Module -Name d365fo.tools -Scope CurrentUser
 ```
-### **List all available commands / functions**
+### List all available commands / functions
 
 ```
 Get-Command -Module d365fo.tools
 ```
 
-### **Update the module**
+### Update the module
 
 ```
 Update-Module -name d365fo.tools
 ```
 
-### **Update the module - force**
+### Update the module - force
 
 ```
 Update-Module -name d365fo.tools -Force
 ```
-## **Getting help**
+## Getting help
 
 The best way to get started and learn about the different cmdlets available is to install the tools onto your D365FO developer box.
 You can also visit the **'docs'** folder in this repository (look at the top). Click this link [**docs**](https://github.com/d365collaborative/d365fo.tools/tree/master/docs) to jump straight inside.
@@ -77,3 +80,7 @@ For sake of the sanity and just trying to help people out, we copy & pasted **al
 ## Contributing
 
 Want to contribute to the project? We'd love to have you! Visit our [contributing.md](https://github.com/d365collaborative/d365fo.tools/blob/master/contributing.md) for a jump start.
+
+## Dependencies
+
+This module depends on other modules. The dependencies are documented in the [dependency graph](https://github.com/d365collaborative/d365fo.tools/network/dependencies) and the Dependencies section of the Package Details of the [package listing](https://www.powershellgallery.com/packages/d365fo.tools) in the PowerShell Gallery.

--- a/d365fo.tools/d365fo.tools.psd1
+++ b/d365fo.tools/d365fo.tools.psd1
@@ -24,7 +24,9 @@
 	PowerShellVersion = '5.0'
 	
 	# Modules that must be imported into the global environment prior to importing
-	# this module
+	# this module.
+	# To enable the GitHub dependency graph, changes should be synchronized with
+	# https://github.com/d365collaborative/d365fo.tools/blob/master/.github/workflows/dependencies.yml
 	RequiredModules   = @(
 		@{ ModuleName = 'PSFramework'; ModuleVersion = '1.0.12' }
 		, @{ ModuleName = 'Azure.Storage'; ModuleVersion = '4.4.0' }


### PR DESCRIPTION
- adds a .yml file to provide a dependencies manifest that the GitHub dependency graph can evaluate
- adds information about dependencies to the ReadMe

I was looking at some older issues ( #504 and #361) and wanted to improve the visibility of the modules dependencies.

You can take a look at the screenshot or https://github.com/FH-Inway/d365fo.tools/network/dependencies to see how the dependency graph would look like.

![image](https://user-images.githubusercontent.com/33372796/152650033-971b33d8-cc53-4032-80b8-8720c36643b4.png)
