### PR TITLE
Fixed IdentityProvider param for 'Import-AadUserIntoD365FO' function

### DIFF
--- a/d365fo.tools/functions/import-d365externaluser.ps1
+++ b/d365fo.tools/functions/import-d365externaluser.ps1
@@ -129,12 +129,13 @@ function Import-D365ExternalUser {
         try {
             $userAuth = Get-D365UserAuthenticationDetail $Email
 
-            $provider = $userAuth.NetworkDomain
+            $provider = $userAuth.IdentityProvider
+            $networkDomain = $userAuth.NetworkDomain
             $sid = $userAuth.SID
             
             Write-PSFMessage -Level Verbose -Message "Extracted sid: $sid"
 
-            Import-AadUserIntoD365FO -SqlCommand $SqlCommand -SignInName $Email -Name $Name -Id $Id -SID $SID -StartUpCompany $Company -IdentityProvider $provider -NetworkDomain $provider -Language $Language
+            Import-AadUserIntoD365FO -SqlCommand $SqlCommand -SignInName $Email -Name $Name -Id $Id -SID $SID -StartUpCompany $Company -IdentityProvider $provider -NetworkDomain $networkDomain -Language $Language
 
             if (Test-PSFFunctionInterrupt) { return }
         }


### PR DESCRIPTION
## Fixed
SSRS reports not working anymore for external users starting from version 10.0.21 (PU 45)

## Cause
The IdentityProvider assigned by `Import-AadUserIntoD365FO` is currently ` https://sts.windows.net/[AADTenantName]` instead of ` https://sts.windows.net/[AADTenantID]`. This causes the SSRS reports to throw "Forbidden" at external users. 

From Microsoft Support:

`The correct value for the IdentityProvider column needs to be https://sts.windows.net/ or https://sts.windows.net/[AADTenantId] in case that the user email has a different domain than admin domain (as in our case).`