### PR TITLE
fix fatal unsafe repository issue for update-wiki.yml

### DIFF
--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Publish wiki folder to repository wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@rsync
+        uses: FH-Inway/github-wiki-publish-action@rsync
         with:
           path: "wiki/"
         env:


### PR DESCRIPTION
Use a modified SwiftDocOrg/github-wiki-publish-action to fix the "fatal: unsafe repository" issue when running the update-wiki.yml action.

Due to a security change in Git made in April, the SwiftDocOrg/github-wiki-publish-action used in the update-wiki.yml fails with a "fatal: unsafe repository" error message. See https://github.com/actions/checkout/issues/760 for more information.

I modified SwiftDocOrg/github-wiki-publish-action in my fork to adress this issue. Since SwiftDocOrg/github-wiki-publish-action has also been archived by the owner, we should continue to use my fork for the time being. At some time, I want to look into replacing it by another GitHub action that provides the same capabilities.