### PR TITLE
fix Rename-D365ComputerName

### DIFF
--- a/d365fo.tools/functions/rename-d365computername.ps1
+++ b/d365fo.tools/functions/rename-d365computername.ps1
@@ -94,9 +94,13 @@ function Rename-D365ComputerName {
         return
     }
 
-    $executable = "$Script:SQLTools\rsconfig.exe"
+    $executable = "$Script:SSRSTools\rsconfig.exe"
 
-    if (-not (Test-PathExists -Path $executable -Type Leaf)) { return }
+    if (-not (Test-PathExists -Path $executable -Type Leaf)) {
+        $executable = "$Script:SQLTools\rsconfig.exe" # fall back to pre 10.0.24
+
+        if (-not (Test-PathExists -Path $executable -Type Leaf)) { return } 
+    }
 
     if (Test-PSFFunctionInterrupt) { return }
 

--- a/d365fo.tools/internal/scripts/variables.ps1
+++ b/d365fo.tools/internal/scripts/variables.ps1
@@ -98,6 +98,8 @@ $Script:TfDir = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE
 
 $Script:SQLTools = "C:\Program Files (x86)\Microsoft SQL Server\130\Tools\Binn"
 
+$Script:SSRSTools = "C:\Program Files\Microsoft SQL Server Reporting Services\Shared Tools"
+
 $Script:DefaultTempPath = "c:\temp\d365fo.tools"
 
 foreach ($item in (Get-PSFConfig -FullName d365fo.tools.active*)) {


### PR DESCRIPTION
On environments running SQL Server 2019, the location of the rsconfig.exe has changed.

Addresses #646 