### PR TITLE
Metadata provider to use path from parameter

### DIFF
--- a/d365fo.tools/functions/get-d365module.ps1
+++ b/d365fo.tools/functions/get-d365module.ps1
@@ -114,7 +114,7 @@ function Get-D365Module {
 
         Write-PSFMessage -Level Verbose -Message "Intializing RuntimeProvider."
 
-        $runtimeProviderConfiguration = New-Object Microsoft.Dynamics.AX.Metadata.Storage.Runtime.RuntimeProviderConfiguration -ArgumentList $Script:PackageDirectory
+        $runtimeProviderConfiguration = New-Object Microsoft.Dynamics.AX.Metadata.Storage.Runtime.RuntimeProviderConfiguration -ArgumentList $PackageDirectory
         $metadataProviderFactoryViaRuntime = New-Object Microsoft.Dynamics.AX.Metadata.Storage.MetadataProviderFactory
         $metadataProviderViaRuntime = $metadataProviderFactoryViaRuntime.CreateRuntimeProvider($runtimeProviderConfiguration)
 


### PR DESCRIPTION
I believe that using `$Script:Script:PackageDirectory` was wrong. If another value was provided in `$PackageDirectory` parameter, we should use it, instead of ignoring it and using the default value anyway.