### PR TITLE
InDependencyOrder param added to Get-D365Module

### DIFF
--- a/d365fo.tools/functions/get-d365module.ps1
+++ b/d365fo.tools/functions/get-d365module.ps1
@@ -15,6 +15,10 @@
         
     .PARAMETER ExcludeBinaryModules
         Instruct the cmdlet to exclude binary modules from the output
+
+    .PARAMETER InDependencyOrder
+        Instructs the cmdlet to return modules in dependency order, starting with modules
+        with no references to other modules.
         
     .PARAMETER BinDir
         The path to the bin directory for the environment
@@ -61,6 +65,20 @@
         ApplicationFoundationFormAdaptor         False    7.0.4841.35227  {ApplicationPlatform, ApplicationFoundation, TestE...
         
     .EXAMPLE
+        PS C:\> Get-D365Module -InDependencyOrder
+
+        Return packages / modules in dependency order, starting with modules with no references to other modules.
+
+        A result set example:
+        
+        ModuleName                               IsBinary Version         References
+        ----------                               -------- -------         ----------
+        ApplicationPlatform                      False    7.0.0.0         {}
+        ApplicationFoundation                    False    7.0.0.0         {ApplicationPlatform}
+        ApplicationCommon                        False    10.21.36.8818   {ApplicationFoundation, ApplicationPlatform}
+        AppTroubleshootingCore                   False    10.21.1136.2... {ApplicationCommon, ApplicationFoundation, Applica...
+
+    .EXAMPLE
         PS C:\> Get-D365Module -Name "Application*Adaptor"
         
         Shows the list of installed packages / modules where the name fits the search "Application*Adaptor".
@@ -88,6 +106,9 @@ function Get-D365Module {
         [string] $Name = "*",
 
         [switch] $ExcludeBinaryModules,
+
+        [Alias("Dependency")]
+        [switch] $InDependencyOrder,
 
         [string] $BinDir = "$Script:BinDir\bin",
 
@@ -120,7 +141,16 @@ function Get-D365Module {
 
         Write-PSFMessage -Level Verbose -Message "MetadataProvider initialized." -Target $metadataProviderViaRuntime
 
-        $modules = $metadataProviderViaRuntime.ModelManifest.ListModules()
+        $modelManifest = $metadataProviderViaRuntime.ModelManifest
+
+        if ($InDependencyOrder -eq $true) {
+            $modules = $modelManifest.ListModulesInDependencyOrder()
+        }
+        else {
+            $modules = $modelManifest.ListModules()
+        }
+
+        
         $modules | ForEach-Object {
             $_ | Add-Member -MemberType NoteProperty -Name 'IsBinary' -Value $false
         }
@@ -146,13 +176,17 @@ function Get-D365Module {
             }
         }
 
-        if($ExcludeBinaryModules -eq $true){
+        if ($ExcludeBinaryModules -eq $true) {
             $modules = $modules | Where-Object IsBinary -eq $false
+        }
+
+        if ($InDependencyOrder -eq $false) {
+            $modules = $modules | Sort-Object Name
         }
 
         Write-PSFMessage -Level Verbose -Message "Looping through all modules."
 
-        foreach ($obj in $($modules | Sort-Object Name)) {
+        foreach ($obj in $modules) {
             Write-PSFMessage -Level Verbose -Message "Filtering out all modules that doesn't match the model search." -Target $obj
             if ($obj.Name -NotLike $Name) { continue }
 

--- a/d365fo.tools/tests/functions/Get-D365Module.Tests.ps1
+++ b/d365fo.tools/tests/functions/Get-D365Module.Tests.ps1
@@ -37,6 +37,19 @@
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
+		It 'Should have the expected parameter InDependencyOrder' {
+			$parameter = (Get-Command Get-D365Module).Parameters['InDependencyOrder']
+			$parameter.Name | Should -Be 'InDependencyOrder'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
 		It 'Should have the expected parameter BinDir' {
 			$parameter = (Get-Command Get-D365Module).Parameters['BinDir']
 			$parameter.Name | Should -Be 'BinDir'
@@ -68,7 +81,7 @@
 	Describe "Testing parameterset __AllParameterSets" {
 		<#
 		__AllParameterSets -
-		__AllParameterSets -Name -ExcludeBinaryModules -BinDir -PackageDirectory
+		__AllParameterSets -Name -ExcludeBinaryModules -InDependencyOrder -BinDir -PackageDirectory
 		#>
 	}
 

--- a/docs/Get-D365Module.md
+++ b/docs/Get-D365Module.md
@@ -13,8 +13,8 @@ Get installed package / module from Dynamics 365 Finance & Operations environmen
 ## SYNTAX
 
 ```
-Get-D365Module [[-Name] <String>] [-ExcludeBinaryModules] [[-BinDir] <String>] [[-PackageDirectory] <String>]
- [<CommonParameters>]
+Get-D365Module [[-Name] <String>] [-ExcludeBinaryModules] [-InDependencyOrder] [[-BinDir] <String>]
+ [[-PackageDirectory] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -57,6 +57,23 @@ ApplicationFoundation                    False    7.0.5493.35504  {ApplicationPl
 ApplicationFoundationFormAdaptor         False    7.0.4841.35227  {ApplicationPlatform, ApplicationFoundation, TestE...
 
 ### EXAMPLE 3
+```
+Get-D365Module -InDependencyOrder
+```
+
+Return packages / modules in dependency order, starting with modules with no references to other modules.
+
+A result set example:
+
+ModuleName                               IsBinary Version         References
+----------                               -------- -------         ----------
+ApplicationPlatform                      False    7.0.0.0         {}
+ApplicationFoundation                    False    7.0.0.0         {ApplicationPlatform}
+ApplicationCommon                        False    10.21.36.8818   {ApplicationFoundation, ApplicationPlatform}
+AppTroubleshootingCore                   False    10.21.1136.2...
+{ApplicationCommon, ApplicationFoundation, Applica...
+
+### EXAMPLE 4
 ```
 Get-D365Module -Name "Application*Adaptor"
 ```
@@ -102,6 +119,22 @@ Instruct the cmdlet to exclude binary modules from the output
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InDependencyOrder
+Instructs the cmdlet to return modules in dependency order, starting with modules
+with no references to other modules.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: Dependency
 
 Required: False
 Position: Named

--- a/wiki/How-To-Compile-Model.md
+++ b/wiki/How-To-Compile-Model.md
@@ -15,7 +15,7 @@ Please visit the [Import d365fo.tools module](https://github.com/d365collaborati
 ## **List all modules / models**
 Listing all installed modules / models can help you while troubleshooting your environment. Type the following command:
 
-```
+```PowerShell
 Get-D365Module
 ```
 
@@ -25,7 +25,7 @@ Get-D365Module
 ## **Search for modules / models**
 To limit the output of modules in the console, you can utilize the search functionality in the `Get-D365Module` cmdlet. Type the following command:
 
-```
+```PowerShell
 Get-D365Module -Name *Project*
 ```
 
@@ -35,7 +35,7 @@ Get-D365Module -Name *Project*
 ## **Compile module / model**
 We need to know the name of the module / model that we want to compile, and provide that as a parameter. Type the following command:
 
-```
+```PowerShell
 Invoke-D365ModuleFullCompile -Module Project
 ```
 
@@ -45,11 +45,14 @@ Invoke-D365ModuleFullCompile -Module Project
 ## **Compile multiple modules / models**
 We can utilize the `Get-D365Module` cmdlet and its output to the PowerShell pipeline, to supply the needed parameters to the `Invoke-D365ModuleFullCompile` cmdlet. Type the following command:
 
-```
+```PowerShell
 Get-D365Module -Name *Project* | Invoke-D365ModuleFullCompile
 ```
 
 [[images/howtos/Compile-Modules.gif]]
+
+You can also use utilize `-InDependencyOrder` parameter of `Get-D365Module` to get and compile modules in the right order. One module
+might depend on other modules and this allows you to compile dependencies first.
 
 ## **Closing comments**
 In this how to we showed you how to compile a specific module / model in a D365FO environment. We also showed you how to combine the `Get-D365Module` cmdlet with the `Invoke-D365ModuleFullCompile` cmdlet to make it easier to compile multiple modules / models.

--- a/wiki/How-To-List-Models.md
+++ b/wiki/How-To-List-Models.md
@@ -15,7 +15,7 @@ Please visit the [Import d365fo.tools module](https://github.com/d365collaborati
 ## **List all modules / models**
 Listing all installed modules / models can help you while troubleshooting your environment. Type the following command:
 
-```
+```PowerShell
 Get-D365Module
 ```
 
@@ -25,7 +25,7 @@ Get-D365Module
 ## **List all modules / models**
 To limit the output of modules in the console, you can utilize the search functionality in the `Get-D365Module` cmdlet. Type the following command:
 
-```
+```PowerShell
 Get-D365Module -Name *Project*
 ```
 


### PR DESCRIPTION
An ability of `Get-D365Module` to return modules in the order in which they should be compiled.
The commit includes changes to documentation and tests.