### PR TITLE
Use PackageDirectory from parameter

### DIFF
--- a/d365fo.tools/functions/get-d365model.ps1
+++ b/d365fo.tools/functions/get-d365model.ps1
@@ -202,7 +202,7 @@ function Get-D365Model {
 
         Write-PSFMessage -Level Verbose -Message "Intializing RuntimeProvider."
 
-        $runtimeProviderConfiguration = New-Object Microsoft.Dynamics.AX.Metadata.Storage.Runtime.RuntimeProviderConfiguration -ArgumentList $Script:PackageDirectory
+        $runtimeProviderConfiguration = New-Object Microsoft.Dynamics.AX.Metadata.Storage.Runtime.RuntimeProviderConfiguration -ArgumentList $PackageDirectory
         $metadataProviderFactoryViaRuntime = New-Object Microsoft.Dynamics.AX.Metadata.Storage.MetadataProviderFactory
         $metadataProviderViaRuntime = $metadataProviderFactoryViaRuntime.CreateRuntimeProvider($runtimeProviderConfiguration)
 
@@ -227,7 +227,7 @@ function Get-D365Model {
 
             $diskModels = $metadataProviderViaDisk.ModelManifest.ListModelInfos()
 
-            foreach($model in $models) {
+            foreach ($model in $models) {
                 if ($diskModels.Name -NotContains $model.Name) {
                     $model.IsBinary = $true
                 }
@@ -238,7 +238,7 @@ function Get-D365Model {
             $models = $models | Where-Object Customization -eq "Allow"
         }
 
-        if($ExcludeBinaryModels -eq $true){
+        if ($ExcludeBinaryModels -eq $true){
             $models = $models | Where-Object IsBinary -eq $false
         }
     }


### PR DESCRIPTION
A minor change, equivalent to what we did in `Get-D365Module`.
`$Script:PackageDirectory` is used as a default value of `$PackageDirectory` and then we should always refer to `$PackageDirectory`, not `$Script:PackageDirectory`.
