### PR TITLE
:package: update default SqlPackage version

### DIFF
--- a/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
+++ b/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
@@ -6,7 +6,8 @@
     .DESCRIPTION
         Download and extract the DotNet/.NET core x64 edition of the SqlPackage.exe to your machine
         
-        It parses the raw html page and tries to extract the latest download link
+        It parses the raw html page and tries to extract the latest download link.
+        As of 12th April 2022, no .NET Core link is available on the download page. The cmdlet will always use the Url parameter.
         
     .PARAMETER Path
         Path to where you want the SqlPackage to be extracted to
@@ -19,7 +20,10 @@
     .PARAMETER Url
         Url/Uri to where the latest SqlPackage download is located
         
-        The default value is for v18.4.1 (15.0.4630.1) as of writing
+        The default value is for v19.1 (16.0.6161.0) as of writing. This is the last version of SqlPackage based on .NET Core.
+        According to the Microsoft documentation, a .NET Core version of SqlPackage should be used.
+        https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/database/import-database
+        Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/issues/708
         
     .EXAMPLE
         PS C:\> Invoke-D365InstallSqlPackage
@@ -65,7 +69,7 @@ function Invoke-D365InstallSqlPackage {
 
         [switch] $SkipExtractFromPage,
 
-        [string] $Url = "https://go.microsoft.com/fwlink/?linkid=2113704"
+        [string] $Url = "https://go.microsoft.com/fwlink/?linkid=2196334"
     )
 
     if (-not $SkipExtractFromPage) {
@@ -76,7 +80,7 @@ function Invoke-D365InstallSqlPackage {
             $Url = ([string]$Matches[1]).Trim()
         }
         else {
-            Write-PSFMessage -Level Host -Message "Parsing the web page didn't succeed. Will fall back to the default download url." -Target "https://docs.microsoft.com/en-us/sql/tools/sqlpackage-download"
+            Write-PSFMessage -Level Host -Message "Parsing the web page didn't succeed. Will fall back to the download url." -Target "https://docs.microsoft.com/en-us/sql/tools/sqlpackage-download"
         }
     }
 


### PR DESCRIPTION
The default SqlPackage version is updated to 19.1, which is the last version based on .NET Core.

See https://github.com/d365collaborative/d365fo.tools/issues/708 for further discussion on this change.