### PR TITLE
:bug: fix computer renaming

### DIFF
--- a/d365fo.tools/internal/sql/rename-computer.sql
+++ b/d365fo.tools/internal/sql/rename-computer.sql
@@ -1,8 +1,8 @@
 ﻿BEGIN TRY
-	EXEC sp_dropserver [@OldComputerName];
+	EXEC sp_dropserver @@SERVERNAME;
 END TRY
 BEGIN CATCH
-	PRINT '@OldComputerName could not be dropped!'
+	PRINT 'Old SQL server name could not be dropped!'
 END CATCH
 
 EXEC sp_addserver [@NewComputerName], local;


### PR DESCRIPTION
Previously, @OldComputerName was used to remove the existing SQL Server. This was based on the assumption that the SQL Server's name is identical to the computer name of the VHD. However, since the 10.0.29 VHD, this is no longer true.

fixes #704