### PR TITLE
Fix documentation and enable pipeline from download to import

### DIFF
--- a/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
+++ b/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
@@ -86,10 +86,10 @@
         
     .EXAMPLE
         PS C:\> Get-D365LcsEnvironmentRsatCertificate -ProjectId "123456789" -EnvironmentId "13cc7700-c13b-4ea3-81cd-2d26fa72ec5e" | Import-D365RsatSelfServiceCertificates
-
+        
         This will download the active rsat certificate file for the environment from the LCS project.
         The resulting files are then imported into the certificate store on the local machine.
-
+        
     .NOTES
         Author: Mötz Jensen (@Splaxi)
 #>

--- a/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
+++ b/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
@@ -84,6 +84,12 @@
         FileName : RSATCertificate_ABC-UAT_20240101-012030.zip
         Password : 9zbPiLMTk676mkq5FvqQ
         
+    .EXAMPLE
+        PS C:\> Get-D365LcsEnvironmentRsatCertificate -ProjectId "123456789" -EnvironmentId "13cc7700-c13b-4ea3-81cd-2d26fa72ec5e" | Import-D365RsatSelfServiceCertificates
+
+        This will download the active rsat certificate file for the environment from the LCS project.
+        The resulting files are then imported into the certificate store on the local machine.
+
     .NOTES
         Author: Mötz Jensen (@Splaxi)
 #>

--- a/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
+++ b/d365fo.tools/functions/get-d365lcsenvironmentrsatcertificate.ps1
@@ -1,12 +1,10 @@
 ﻿
 <#
     .SYNOPSIS
-        Get LCS environment meta data from within a project
+        Get LCS environment rsat certificate from within a project
         
     .DESCRIPTION
-        Get all meta data details for environments from within a LCS project
-        
-        It supports listing all environments, but also supports single / specific environments by searching based on EnvironmentId or EnvironmentName
+        Download and persist the active rsat certificate from environments from within a LCS project
         
     .PARAMETER ProjectId
         The project id for the Dynamics 365 for Finance & Operations project inside LCS

--- a/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
+++ b/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
@@ -21,7 +21,7 @@
     .EXAMPLE
         PS C:\> Import-D365RsatSelfServiceCertificates -Path "C:\Temp\UAT" -Password "123456789"
         
-        This will import the .cer and .pxf files into the correct stored, bases on the files located in "C:\Temp\UAT".
+        This will import the .cer and .pxf files into the correct store, bases on the files located in "C:\Temp\UAT".
         After import it will display the thumbprint for both certificates.
         
         Sample output:
@@ -37,10 +37,14 @@ function Import-D365RsatSelfServiceCertificates {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "")]
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory = $true)]
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName)]
         $Path,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName)]
         $Password
     )
     

--- a/d365fo.tools/tests/functions/Import-D365RsatSelfServiceCertificates.Tests.ps1
+++ b/d365fo.tools/tests/functions/Import-D365RsatSelfServiceCertificates.Tests.ps1
@@ -21,7 +21,7 @@
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
 			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $True
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
 		It 'Should have the expected parameter Password' {
@@ -34,7 +34,7 @@
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
 			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 1
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $True
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
 	}

--- a/docs/Get-D365LcsEnvironmentRsatCertificate.md
+++ b/docs/Get-D365LcsEnvironmentRsatCertificate.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-D365LcsEnvironmentRsatCertificate
 
 ## SYNOPSIS
-Get LCS environment meta data from within a project
+Get LCS environment rsat certificate from within a project
 
 ## SYNTAX
 
@@ -19,9 +19,7 @@ Get-D365LcsEnvironmentRsatCertificate [[-ProjectId] <Int32>] [[-BearerToken] <St
 ```
 
 ## DESCRIPTION
-Get all meta data details for environments from within a LCS project
-
-It supports listing all environments, but also supports single / specific environments by searching based on EnvironmentId or EnvironmentName
+Download and persist the active rsat certificate from environments from within a LCS project
 
 ## EXAMPLES
 
@@ -41,6 +39,14 @@ CerFile  : C:\temp\d365fo.tools\RsatCert\RSATCertificate_ABC-UAT_20240101-012030
 PfxFile  : C:\temp\d365fo.tools\RsatCert\RSATCertificate_ABC-UAT_20240101-012030\RSATCertificate_ABC-UAT_20240101-012030.pfx
 FileName : RSATCertificate_ABC-UAT_20240101-012030.zip
 Password : 9zbPiLMTk676mkq5FvqQ
+
+### EXAMPLE 2
+```
+Get-D365LcsEnvironmentRsatCertificate -ProjectId "123456789" -EnvironmentId "13cc7700-c13b-4ea3-81cd-2d26fa72ec5e" | Import-D365RsatSelfServiceCertificates
+```
+
+This will download the active rsat certificate file for the environment from the LCS project.
+The resulting files are then imported into the certificate store on the local machine.
 
 ## PARAMETERS
 

--- a/docs/Import-D365RsatSelfServiceCertificates.md
+++ b/docs/Import-D365RsatSelfServiceCertificates.md
@@ -29,7 +29,7 @@ The zip file needs to be unblocked and then extracted into a folder, with only t
 Import-D365RsatSelfServiceCertificates -Path "C:\Temp\UAT" -Password "123456789"
 ```
 
-This will import the .cer and .pxf files into the correct stored, bases on the files located in "C:\Temp\UAT".
+This will import the .cer and .pxf files into the correct store, bases on the files located in "C:\Temp\UAT".
 After import it will display the thumbprint for both certificates.
 
 Sample output:
@@ -51,7 +51,7 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 
@@ -68,7 +68,7 @@ Aliases:
 Required: True
 Position: 2
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName)
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
- fixes a copy&paste issue in the documentation of the new Get-D365LcsEnvironmentRsatCertificate
- adds experimental pipeline support so the result of Get-D365LcsEnvironmentRsatCertificate can be piped to Import-D365RsatSelfServiceCertificates