### PR TITLE
Fix import rsat certificate pipeline

### DIFF
--- a/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
+++ b/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
@@ -1,4 +1,4 @@
-﻿
+
 <#
     .SYNOPSIS
         Import certificates for RSAT
@@ -39,13 +39,15 @@ function Import-D365RsatSelfServiceCertificates {
     param (
         [Parameter(
             Mandatory = $true,
-            ValueFromPipelineByPropertyName)]
-        $Path,
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Path,
 
         [Parameter(
             Mandatory = $true,
-            ValueFromPipelineByPropertyName)]
-        $Password
+            ValueFromPipelineByPropertyName = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Password
     )
     
     begin {

--- a/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
+++ b/d365fo.tools/functions/import-d365rsatselfservicecertificates.ps1
@@ -1,4 +1,4 @@
-
+﻿
 <#
     .SYNOPSIS
         Import certificates for RSAT
@@ -51,12 +51,14 @@ function Import-D365RsatSelfServiceCertificates {
     )
     
     begin {
-        [Security.SecureString] $PasswordSecure = (ConvertTo-SecureString -String $Password -Force -AsPlainText)
-
-        if (-not (Test-PathExists -Path $Path -Type Container)) { return }
+        
     }
     
     process {
+        [Security.SecureString] $PasswordSecure = (ConvertTo-SecureString -String $Password -Force -AsPlainText)
+    
+        if (-not (Test-PathExists -Path $Path -Type Container)) { return }
+
         if (Test-PSFFunctionInterrupt) { return }
 
         $pathCertFile = (Get-ChildItem -Path "$Path\*.cer" | Select-Object -First 1).FullName

--- a/d365fo.tools/tests/functions/Import-D365RsatSelfServiceCertificates.Tests.ps1
+++ b/d365fo.tools/tests/functions/Import-D365RsatSelfServiceCertificates.Tests.ps1
@@ -14,7 +14,7 @@
 		It 'Should have the expected parameter Path' {
 			$parameter = (Get-Command Import-D365RsatSelfServiceCertificates).Parameters['Path']
 			$parameter.Name | Should -Be 'Path'
-			$parameter.ParameterType.ToString() | Should -Be System.Object
+			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
@@ -27,7 +27,7 @@
 		It 'Should have the expected parameter Password' {
 			$parameter = (Get-Command Import-D365RsatSelfServiceCertificates).Parameters['Password']
 			$parameter.Name | Should -Be 'Password'
-			$parameter.ParameterType.ToString() | Should -Be System.Object
+			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'

--- a/docs/Import-D365RsatSelfServiceCertificates.md
+++ b/docs/Import-D365RsatSelfServiceCertificates.md
@@ -13,7 +13,7 @@ Import certificates for RSAT
 ## SYNTAX
 
 ```
-Import-D365RsatSelfServiceCertificates [-Path] <Object> [-Password] <Object> [<CommonParameters>]
+Import-D365RsatSelfServiceCertificates [-Path] <String> [-Password] <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -44,7 +44,7 @@ Path to the folder where the .cer and .pxf files are located
 The files needs to be extracted from the zip archive
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 
@@ -61,7 +61,7 @@ Password for the .pxf file
 Working with self-service environments, the password will be displayed during the download of the zip archive
 
 ```yaml
-Type: Object
+Type: String
 Parameter Sets: (All)
 Aliases:
 


### PR DESCRIPTION
The changes from #803 to enable pipelining the output from Get-D365LcsEnvironmentRsatCertificate to Import-D365RsatSelfServiceCertificates did not work. An error ocurred that the $Password and $Path parameters are empty. This was caused because some logic that operates on the parameters was placed in the begin block of the Import-D365RsatSelfServiceCertificates cmdlet. Piped input is only available in the process block.