### PR TITLE
Disk provider binary-only module reference fix

### DIFF
--- a/d365fo.tools/functions/get-d365module.ps1
+++ b/d365fo.tools/functions/get-d365module.ps1
@@ -162,7 +162,7 @@ function Get-D365Module {
             $diskProviderConfiguration = New-Object Microsoft.Dynamics.AX.Metadata.Storage.DiskProvider.DiskProviderConfiguration
             $diskProviderConfiguration.AddMetadataPath($PackageDirectory)
             $metadataProviderFactoryViaDisk = New-Object Microsoft.Dynamics.AX.Metadata.Storage.MetadataProviderFactory
-            $metadataProviderViaDisk = $metadataProviderFactoryViaDisk.CreateDiskProvider($diskProviderConfiguration)
+            $metadataProviderViaDisk = $metadataProviderFactoryViaDisk.CreateDiskProvider($diskProviderConfiguration, $metadataProviderViaRuntime.ModelManifest)
 
             Write-PSFMessage -Level Verbose -Message "MetadataProvider initialized." -Target $metadataProviderViaDisk
 


### PR DESCRIPTION
If a module that is read by the disk metadata provider references a binary-only module, the "ListModulesInDependencyOrder()" method causes an exception error that is catched by the Get-D365Module function in line 172. As a result, the order of the modules cannot be determined taking the dependencies into account and "ListModules" is used instead. The problem can be easily avoided by adding the model manifest of the runtime metadata provider to the "CreateDiskProvider" method in line 165.

This ensures that the disk provider has all the information it needs to determine the sequence for all modules based on the dependencies.