### PR TITLE
Update Invoke-D365InstallSqlPackage to install latest version of SQLPackage

### DIFF
--- a/d365fo.tools/bin/d365fo.tools-index.json
+++ b/d365fo.tools/bin/d365fo.tools-index.json
@@ -435,6 +435,35 @@
         "Syntax":  "Backup-D365WebConfig [[-OutputPath] \u003cString\u003e] [-Force] [\u003cCommonParameters\u003e]"
     },
     {
+        "CommandName":  "Backup-D365WifConfig",
+        "Description":  "Will backup the wif.config file located in the AOS / IIS folder",
+        "Params":  [
+                       [
+                           "OutputPath",
+                           "Path to the folder where you want the web.config file to be persisted\nDefault is: \"C:\\Temp\\d365fo.tools\\WifConfigBackup\"",
+                           "",
+                           false,
+                           "false",
+                           "$(Join-Path $Script:DefaultTempPath \"WifConfigBackup\")"
+                       ],
+                       [
+                           "Force",
+                           "Instructs the cmdlet to overwrite the destination file if it already exists",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ]
+                   ],
+        "Alias":  "",
+        "Author":  "Florian Hopfner (@FH-Inway)",
+        "Synopsis":  "Backup the wif.config file",
+        "Name":  "Backup-D365WifConfig",
+        "Links":  null,
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eBackup-D365WifConfig\nWill locate the wif.config file, and back it up.\r\nIt will look for the file in the AOS / IIS folder. E.g. K:\\AosService\\WebRoot\\wif.config.\r\nIt will save the file to the default location: \"C:\\Temp\\d365fo.tools\\WifConfigBackup\".\nA result set example:\nFilename   LastModified         File\r\n--------   ------------         ----\r\nwif.config 6/29/2021 7:31:04 PM C:\\temp\\d365fo.tools\\WifConfigBackup\\wif.config\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eBackup-D365WifConfig -Force\nWill locate the wif.config file, back it up, and overwrite if a previous backup file exists.\r\nIt will look for the file in the AOS / IIS folder. E.g. K:\\AosService\\WebRoot\\wif.config.\r\nIt will save the file to the default location: \"C:\\Temp\\d365fo.tools\\WifConfigBackup\".\r\nIt will overwrite any file named wif.config in the destination folder.\nA result set example:\nFilename   LastModified         File\r\n--------   ------------         ----\r\nwif.config 6/29/2021 7:31:04 PM C:\\temp\\d365fo.tools\\WifConfigBackup\\wif.config",
+        "Syntax":  "Backup-D365WifConfig [[-OutputPath] \u003cString\u003e] [-Force] [\u003cCommonParameters\u003e]"
+    },
+    {
         "CommandName":  "Clear-D365ActiveBroadcastMessageConfig",
         "Description":  "Clear the active broadcast message config from the configuration store",
         "Tags":  [
@@ -7622,7 +7651,7 @@
     },
     {
         "CommandName":  "Invoke-D365InstallSqlPackage",
-        "Description":  "Download and extract the DotNet/.NET core x64 edition of the SqlPackage.exe to your machine\n\nIt parses the raw html page and tries to extract the latest download link.\nAs of 12th April 2022, no .NET Core link is available on the download page. The cmdlet will always use the Url parameter.",
+        "Description":  "Download and extract SqlPackage.exe to your machine.",
         "Params":  [
                        [
                            "Path",
@@ -7633,8 +7662,8 @@
                            "C:\\temp\\d365fo.tools\\SqlPackage"
                        ],
                        [
-                           "SkipExtractFromPage",
-                           "Instruct the cmdlet to skip trying to parse the download page and to rely on the Url parameter only",
+                           "Latest",
+                           "Overrides the Url parameter and uses the latest download URL provided by the evergreen link https://aka.ms/sqlpackage-windows",
                            "",
                            false,
                            "false",
@@ -7642,11 +7671,11 @@
                        ],
                        [
                            "Url",
-                           "Url/Uri to where the latest SqlPackage download is located\nThe default value is for v19.1 (16.0.6161.0) as of writing. This is the last version of SqlPackage based on .NET Core.\r\nAccording to the Microsoft documentation, a .NET Core version of SqlPackage should be used.\r\nhttps://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/database/import-database\r\nFurther discussion can be found here: https://github.com/d365collaborative/d365fo.tools/issues/708",
+                           "Url/Uri to where the SqlPackage download is located\nThe default value is for version 162.2.111.2 as of writing.\nFurther discussion can be found here: https://github.com/d365collaborative/d365fo.tools/discussions/816",
                            "",
                            false,
                            "false",
-                           "https://go.microsoft.com/fwlink/?linkid=2196334"
+                           "https://go.microsoft.com/fwlink/?linkid=2261576"
                        ]
                    ],
         "Alias":  "",
@@ -7654,8 +7683,8 @@
         "Synopsis":  "Download SqlPackage.exe to your machine",
         "Name":  "Invoke-D365InstallSqlPackage",
         "Links":  null,
-        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage\nThis will download and extract the latest SqlPackage.exe.\r\nIt will use the default value for the Path parameter, for where to save the SqlPackage.exe.\r\nIt will try to extract the latest download URL from the RAW html page.\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -Path \"C:\\temp\\SqlPackage\"\nThis will download and extract the latest SqlPackage.exe.\r\nIt will try to extract the latest download URL from the RAW html page.\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -SkipExtractFromPage\nThis will download and extract the latest SqlPackage.exe.\r\nIt will rely on the Url parameter to based the download from.\r\nIt will use the default value of the Url parameter.\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -SkipExtractFromPage -Url \"https://go.microsoft.com/fwlink/?linkid=3030303\"\nThis will download and extract the latest SqlPackage.exe.\r\nIt will rely on the Url parameter to based the download from.\r\nIt will use the \"https://go.microsoft.com/fwlink/?linkid=3030303\" as value for the Url parameter.\r\nIt will update the path for the SqlPackage.exe in configuration.",
-        "Syntax":  "Invoke-D365InstallSqlPackage [[-Path] \u003cString\u003e] [-SkipExtractFromPage] [[-Url] \u003cString\u003e] [\u003cCommonParameters\u003e]"
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage\nThis will download and extract SqlPackage.exe.\r\nIt will use the default value for the Path parameter, for where to save the SqlPackage.exe.\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -Path \"C:\\temp\\SqlPackage\"\nThis will download and extract SqlPackage.exe.\r\nIt will save the SqlPackage.exe to \"C:\\temp\\SqlPackage\".\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -Latest\nThis will download and extract the latest SqlPackage.exe.\r\nIt will use https://aka.ms/sqlpackage-windows as the download URL.\r\nIt will update the path for the SqlPackage.exe in configuration.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eInvoke-D365InstallSqlPackage -Url \"https://go.microsoft.com/fwlink/?linkid=3030303\"\nThis will download and extract SqlPackage.exe.\r\nIt will rely on the Url parameter to base the download on.\r\nIt will use the \"https://go.microsoft.com/fwlink/?linkid=3030303\" as value for the Url parameter.\r\nIt will update the path for the SqlPackage.exe in configuration.",
+        "Syntax":  "Invoke-D365InstallSqlPackage [-Path \u003cString\u003e] [-Url \u003cString\u003e] [\u003cCommonParameters\u003e]\nInvoke-D365InstallSqlPackage [-Path \u003cString\u003e] [-Latest] [\u003cCommonParameters\u003e]"
     },
     {
         "CommandName":  "Invoke-D365LcsApiRefreshToken",
@@ -9568,7 +9597,7 @@
     },
     {
         "CommandName":  "New-D365EntraIntegration",
-        "Description":  "Enable the Microsoft Entra ID integration by executing some of the steps described in https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-tools/secure-developer-vm#external-integrations.\nThe integration can either be enabled with an existing certificate or a new self-signed certificate can be created.\nIf a new certificate is created and the integration is also to be enabled on other environments with the same certificate, a certificate password must be specified in order to create a certificate private key file.\n\nThe steps executed are:\n\n1. Create a self-signed certificate and save it to Desktop or use a provided certificate.\n2. Install the certificate to the \"LocalMachine\" certificate store.\n3. Grant NetworkService READ permission to the certificate (only on cloud-hosted environments).\n4. Update the web.config with the application ID and the thumbprint of the certificate.\n\nTo execute the steps, the id of an Azure application must be provided. The application must have the following API permissions:\n\na. Dynamics ERP - This permission is required to access finance and operations environments.\nb. Microsoft Graph (User.Read.All and Group.Read.All permissions of the Application type).\n\nThe URL of the finance and operations environment must also be added to the RedirectURI in the Authentication section of the Azure application.\nFinally, after running the cmdlet, if a new certificate was created, it must be uploaded to the Azure application.",
+        "Description":  "Enable the Microsoft Entra ID integration by executing some of the steps described in https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-tools/secure-developer-vm#external-integrations.\nThe integration can either be enabled with an existing certificate or a new self-signed certificate can be created.\nIf a new certificate is created and the integration is also to be enabled on other environments with the same certificate, a certificate password must be specified in order to create a certificate private key file.\n\nThe steps executed are:\n\n- 1) Create a self-signed certificate and save it to Desktop or use a provided certificate.\n- 2) Install the certificate to the \"LocalMachine\" certificate store.\n- 3) Grant NetworkService READ permission to the certificate (only on cloud-hosted environments).\n- 4) Update the web.config with the application ID and the thumbprint of the certificate.\n- 5) (Optional) Add the application registration to the WIF config.\n\nTo execute the steps, the id of an Azure application must be provided. The application must have the following API permissions:\n\n- Dynamics ERP - This permission is required to access finance and operations environments.\n- Microsoft Graph (User.Read.All and Group.Read.All permissions of the Application type).\n\nThe URL of the finance and operations environment must also be added to the RedirectURI in the Authentication section of the Azure application.\nFinally, after running the cmdlet, if a new certificate was created, it must be uploaded to the Azure application.",
         "Params":  [
                        [
                            "ClientId",
@@ -9643,6 +9672,14 @@
                            "False"
                        ],
                        [
+                           "AddAppRegistrationToWifConfig",
+                           "Adds the application registration to the WIF config. This is not part of the official Microsoft documentation to enable the Entra ID integration. It is however highly recommended to fix additional \r\nissues with the missing entry integration.",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ],
+                       [
                            "WhatIf",
                            "Executes the cmdlet until the first operation that would change the state of the system, without executing that operation.\r\nSubsequent operations are likely to fail.\r\nThis is currently not fully implemented and should not be used.",
                            "wi",
@@ -9664,8 +9701,8 @@
         "Synopsis":  "Enable the Microsoft Entra ID integration on a cloud hosted environment (CHE).",
         "Name":  "New-D365EntraIntegration",
         "Links":  null,
-        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -ClientId e70cac82-6a7c-4f9e-a8b9-e707b961e986\nEnables the Entra ID integration with a new self-signed certificate named \"CHEAuth\" which expires after 2 years.\n-------------------------- EXAMPLE 2 --------------------------\nPS c:\\\u003eNew-D365EntraIntegration -ClientId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificateName \"SelfsignedCert\"\nEnables the Entra ID integration with a new self-signed certificate with the name \"Selfsignedcert\" that expires after 2 years.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificateName \"SelfsignedCert\" -CertificateExpirationYears 1\nEnables the Entra ID integration with a new self-signed certificate with the name \"SelfsignedCert\" that expires after 1 year.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003e$securePassword = Read-Host -AsSecureString -Prompt \"Enter the certificate password\"\nPS C:\\\u003e New-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificatePassword $securePassword\nEnables the Entra ID integration with a new self-signed certificate with the name \"CHEAuth\" that expires after 2 years, using the provided password to generate the private key of the certificate.\r\nThe certificate file and the private key file are saved to the Desktop of the current user.\n-------------------------- EXAMPLE 5 --------------------------\nPS C:\\\u003e$securePassword = Read-Host -AsSecureString -Prompt \"Enter the certificate password\"\nPS C:\\\u003e New-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -ExistingCertificateFile \"C:\\Temp\\SelfsignedCert.cer\" -ExistingCertificatePrivateKeyFile \"C:\\Temp\\SelfsignedCert.pfx\" \r\n-CertificatePassword $securePassword\nEnables the Entra ID integration with the certificate file \"C:\\Temp\\SelfsignedCert.cer\", the private key file \"C:\\Temp\\SelfsignedCert.pfx\" and the provided password to install it.",
-        "Syntax":  "New-D365EntraIntegration -ClientId \u003cString\u003e [-CertificateName \u003cString\u003e] [-CertificateExpirationYears \u003cInt32\u003e] [-NewCertificateFile \u003cString\u003e] [-NewCertificatePrivateKeyFile \u003cString\u003e] [-CertificatePassword \u003cSecureString\u003e] [-Force] [-WhatIf] [-Confirm] [\u003cCommonParameters\u003e]\nNew-D365EntraIntegration -ClientId \u003cString\u003e -ExistingCertificateFile \u003cString\u003e [-ExistingCertificatePrivateKeyFile \u003cString\u003e] [-CertificatePassword \u003cSecureString\u003e] [-Force] [-WhatIf] [-Confirm] [\u003cCommonParameters\u003e]"
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -ClientId e70cac82-6a7c-4f9e-a8b9-e707b961e986\nEnables the Entra ID integration with a new self-signed certificate named \"CHEAuth\" which expires after 2 years.\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -ClientId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -AddAppRegistrationToWifConfig\nEnables the Entra ID integration with a new self-signed certificate named \"CHEAuth\" which expires after 2 years and adds the application registration to the wif.config.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -ClientId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificateName \"SelfsignedCert\"\nEnables the Entra ID integration with a new self-signed certificate with the name \"Selfsignedcert\" that expires after 2 years.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eNew-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificateName \"SelfsignedCert\" -CertificateExpirationYears 1\nEnables the Entra ID integration with a new self-signed certificate with the name \"SelfsignedCert\" that expires after 1 year.\n-------------------------- EXAMPLE 5 --------------------------\nPS C:\\\u003e$securePassword = Read-Host -AsSecureString -Prompt \"Enter the certificate password\"\nPS C:\\\u003e New-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -CertificatePassword $securePassword\nEnables the Entra ID integration with a new self-signed certificate with the name \"CHEAuth\" that expires after 2 years, using the provided password to generate the private key of the certificate.\r\nThe certificate file and the private key file are saved to the Desktop of the current user.\n-------------------------- EXAMPLE 6 --------------------------\nPS C:\\\u003e$securePassword = Read-Host -AsSecureString -Prompt \"Enter the certificate password\"\nPS C:\\\u003e New-D365EntraIntegration -AppId e70cac82-6a7c-4f9e-a8b9-e707b961e986 -ExistingCertificateFile \"C:\\Temp\\SelfsignedCert.cer\" -ExistingCertificatePrivateKeyFile \"C:\\Temp\\SelfsignedCert.pfx\" \r\n-CertificatePassword $securePassword\nEnables the Entra ID integration with the certificate file \"C:\\Temp\\SelfsignedCert.cer\", the private key file \"C:\\Temp\\SelfsignedCert.pfx\" and the provided password to install it.",
+        "Syntax":  "New-D365EntraIntegration -ClientId \u003cString\u003e [-CertificateName \u003cString\u003e] [-CertificateExpirationYears \u003cInt32\u003e] [-NewCertificateFile \u003cString\u003e] [-NewCertificatePrivateKeyFile \u003cString\u003e] [-CertificatePassword \u003cSecureString\u003e] [-Force] [-AddAppRegistrationToWifConfig] [-WhatIf] [-Confirm] [\u003cCommonParameters\u003e]\nNew-D365EntraIntegration -ClientId \u003cString\u003e -ExistingCertificateFile \u003cString\u003e [-ExistingCertificatePrivateKeyFile \u003cString\u003e] [-CertificatePassword \u003cSecureString\u003e] [-Force] [-AddAppRegistrationToWifConfig] [-WhatIf] [-Confirm] [\u003cCommonParameters\u003e]"
     },
     {
         "CommandName":  "New-D365ISVLicense",

--- a/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
+++ b/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
@@ -17,8 +17,8 @@
     .PARAMETER Url
         Url/Uri to where the SqlPackage download is located
         
-        The default value is for version 162.2.111.2 as of writing. 
-
+        The default value is for version 162.2.111.2 as of writing.
+        
         Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/discussions/816
         
     .EXAMPLE

--- a/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
+++ b/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
@@ -101,7 +101,7 @@ function Invoke-D365InstallSqlPackage {
     $SqlPackagePath = Join-Path -Path $Path -ChildPath "SqlPackage.exe"
     Set-D365SqlPackagePath -Path $SqlPackagePath
 
-    $result = Invoke-Process -Path $SqlPackagePath -Params "/Version" 
+    $result = Invoke-Process -Path $SqlPackagePath -Params "/Version"
     $version = $result.stdout -replace "`r`n", ""
 
     Write-PSFMessage -Level Host -Message "SqlPackage.exe version $version has been downloaded and extracted to $SqlPackagePath"

--- a/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
+++ b/d365fo.tools/functions/invoke-d365installsqlpackage.ps1
@@ -4,84 +4,75 @@
         Download SqlPackage.exe to your machine
         
     .DESCRIPTION
-        Download and extract the DotNet/.NET core x64 edition of the SqlPackage.exe to your machine
-        
-        It parses the raw html page and tries to extract the latest download link.
-        As of 12th April 2022, no .NET Core link is available on the download page. The cmdlet will always use the Url parameter.
+        Download and extract SqlPackage.exe to your machine.
         
     .PARAMETER Path
         Path to where you want the SqlPackage to be extracted to
         
         Default value is: "C:\temp\d365fo.tools\SqlPackage\SqlPackage.exe"
         
-    .PARAMETER SkipExtractFromPage
-        Instruct the cmdlet to skip trying to parse the download page and to rely on the Url parameter only
+    .PARAMETER Latest
+        Overrides the Url parameter and uses the latest download URL provided by the evergreen link https://aka.ms/sqlpackage-windows
         
     .PARAMETER Url
-        Url/Uri to where the latest SqlPackage download is located
+        Url/Uri to where the SqlPackage download is located
         
-        The default value is for v19.1 (16.0.6161.0) as of writing. This is the last version of SqlPackage based on .NET Core.
-        According to the Microsoft documentation, a .NET Core version of SqlPackage should be used.
-        https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/database/import-database
-        Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/issues/708
+        The default value is for version 162.2.111.2 as of writing. 
+
+        Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/discussions/816
         
     .EXAMPLE
         PS C:\> Invoke-D365InstallSqlPackage
         
-        This will download and extract the latest SqlPackage.exe.
+        This will download and extract SqlPackage.exe.
         It will use the default value for the Path parameter, for where to save the SqlPackage.exe.
-        It will try to extract the latest download URL from the RAW html page.
         It will update the path for the SqlPackage.exe in configuration.
         
     .EXAMPLE
         PS C:\> Invoke-D365InstallSqlPackage -Path "C:\temp\SqlPackage"
         
-        This will download and extract the latest SqlPackage.exe.
-        It will try to extract the latest download URL from the RAW html page.
+        This will download and extract SqlPackage.exe.
+        It will save the SqlPackage.exe to "C:\temp\SqlPackage".
         It will update the path for the SqlPackage.exe in configuration.
         
     .EXAMPLE
-        PS C:\> Invoke-D365InstallSqlPackage -SkipExtractFromPage
+        PS C:\> Invoke-D365InstallSqlPackage -Latest
         
         This will download and extract the latest SqlPackage.exe.
-        It will rely on the Url parameter to based the download from.
-        It will use the default value of the Url parameter.
+        It will use https://aka.ms/sqlpackage-windows as the download URL.
         It will update the path for the SqlPackage.exe in configuration.
         
     .EXAMPLE
-        PS C:\> Invoke-D365InstallSqlPackage -SkipExtractFromPage -Url "https://go.microsoft.com/fwlink/?linkid=3030303"
+        PS C:\> Invoke-D365InstallSqlPackage -Url "https://go.microsoft.com/fwlink/?linkid=3030303"
         
-        This will download and extract the latest SqlPackage.exe.
-        It will rely on the Url parameter to based the download from.
+        This will download and extract SqlPackage.exe.
+        It will rely on the Url parameter to base the download on.
         It will use the "https://go.microsoft.com/fwlink/?linkid=3030303" as value for the Url parameter.
         It will update the path for the SqlPackage.exe in configuration.
         
     .NOTES
         Author: Mötz Jensen (@Splaxi)
+        Author: Florian Hopfner (@FH-Inway)
 #>
 
 function Invoke-D365InstallSqlPackage {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "")]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ImportUrl')]
     [OutputType()]
     param (
+        [Parameter(ParameterSetName = 'ImportUrl')]
+        [Parameter(ParameterSetName = 'ImportLatest')]
         [string] $Path = "C:\temp\d365fo.tools\SqlPackage",
-
-        [switch] $SkipExtractFromPage,
-
-        [string] $Url = "https://go.microsoft.com/fwlink/?linkid=2196334"
+        
+        [Parameter(ParameterSetName = 'ImportLatest')]
+        [switch] $Latest,
+        
+        [Parameter(ParameterSetName = 'ImportUrl')]
+        [string] $Url = "https://go.microsoft.com/fwlink/?linkid=2261576"
     )
 
-    if (-not $SkipExtractFromPage) {
-        $content = (Invoke-WebRequest -Uri "https://learn.microsoft.com/en-us/sql/tools/sqlpackage-download" -UseBasicParsing).content
-        $res = $content -match '<td.*>Windows .NET Core<.*/td>\s*<td.*><a href="(https://.*)" .*'
-        
-        if ($res) {
-            $Url = ([string]$Matches[1]).Trim()
-        }
-        else {
-            Write-PSFMessage -Level Host -Message "Parsing the web page didn't succeed. Will fall back to the download url." -Target "https://learn.microsoft.com/en-us/sql/tools/sqlpackage-download"
-        }
+    if ($Latest) {
+        $Url = "https://aka.ms/sqlpackage-windows"
     }
 
     $sqlPackageFolder = $Path
@@ -107,5 +98,11 @@ function Invoke-D365InstallSqlPackage {
     $tempExtractPath | Remove-Item -Force -Recurse
     $downloadPath | Remove-Item -Force -Recurse
 
-    Set-D365SqlPackagePath -Path $(Join-Path -Path $Path -ChildPath "SqlPackage.exe")
+    $SqlPackagePath = Join-Path -Path $Path -ChildPath "SqlPackage.exe"
+    Set-D365SqlPackagePath -Path $SqlPackagePath
+
+    $result = Invoke-Process -Path $SqlPackagePath -Params "/Version" 
+    $version = $result.stdout -replace "`r`n", ""
+
+    Write-PSFMessage -Level Host -Message "SqlPackage.exe version $version has been downloaded and extracted to $SqlPackagePath"
 }

--- a/d365fo.tools/internal/functions/invoke-process.ps1
+++ b/d365fo.tools/internal/functions/invoke-process.ps1
@@ -144,4 +144,12 @@ function Invoke-Process {
     }
 
     Invoke-TimeSignal -End
+
+    if (-not $ShowOriginalProgress) {
+        [PSCustomObject]@{
+            stdout = $stdout
+            stderr = $stderr
+            ExitCode = $p.ExitCode
+        }
+    }
 }

--- a/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
+++ b/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
@@ -217,6 +217,10 @@ function Invoke-SqlPackage {
         $Params.Add("/MaxParallelism:$MaxParallelism") > $null
     }
 
+    $result = Invoke-Process -Path $executable -Params "/Version" 
+    $version = $result.stdout -replace "`r`n", ""
+    Write-PSFMessage -Level Verbose -Message "Using SQLPackage version $version"
+
     Invoke-Process -Executable $executable -Params $params -ShowOriginalProgress:$ShowOriginalProgress -OutputCommandOnly:$OutputCommandOnly -LogPath $LogPath
     
     if (Test-PSFFunctionInterrupt) {

--- a/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
+++ b/d365fo.tools/internal/functions/invoke-sqlpackage.ps1
@@ -1,74 +1,73 @@
-﻿
-<#
+﻿<#
     .SYNOPSIS
         Invoke the sqlpackage executable
-        
+
     .DESCRIPTION
         Invoke the sqlpackage executable and pass the necessary parameters to it
-        
+
     .PARAMETER Action
         Can either be import or export
-        
+
     .PARAMETER DatabaseServer
         The name of the database server
-        
+
         If on-premises or classic SQL Server, use either short name og Fully Qualified Domain Name (FQDN).
-        
+
         If Azure use the full address to the database server, e.g. server.database.windows.net
-        
+
     .PARAMETER DatabaseName
         The name of the database
-        
+
     .PARAMETER SqlUser
         The login name for the SQL Server instance
-        
+
     .PARAMETER SqlPwd
         The password for the SQL Server user
-        
+
     .PARAMETER TrustedConnection
         Should the sqlpackage work with TrustedConnection or not
-        
+
     .PARAMETER FilePath
         Path to the file, used for either import or export
-        
+
     .PARAMETER Properties
         Array of all the properties that needs to be parsed to the sqlpackage.exe
-        
+
     .PARAMETER DiagnosticFile
         Path to where you want the SqlPackage to output a diagnostics file to assist you in troubleshooting
-        
+
     .PARAMETER ModelFile
         Path to the model file that you want the SqlPackage.exe to use instead the one being part of the bacpac file
-        
+
         This is used to override SQL Server options, like collation and etc
-        
+
     .PARAMETER MaxParallelism
         Sets SqlPackage.exe's degree of parallelism for concurrent operations running against a database
-        
+
         The default value is 8
-        
+
     .PARAMETER PublishFile
         Path to the profile / publish xml file that contains all the advanced configuration instructions for the SqlPackage
-        
+
         Used only in combination with the Publish action
-        
+
     .PARAMETER LogPath
         The path where the log file(s) will be saved
-        
+
     .PARAMETER ShowOriginalProgress
         Instruct the cmdlet to show the standard output in the console
-        
+
         Default is $false which will silence the standard output
-        
+
     .PARAMETER OutputCommandOnly
         Instruct the cmdlet to only output the command that you would have to execute by hand
-        
+
         Will include full path to the executable and the needed parameters based on your selection
-        
+
     .PARAMETER EnableException
         This parameters disables user-friendly warnings and enables the throwing of exceptions
         This is less user friendly, but allows catching exceptions in calling scripts
-        
+
     .EXAMPLE
         PS C:\> $BaseParams = @{
         DatabaseServer = $DatabaseServer
@@ -76,19 +75,19 @@
         SqlUser        = $SqlUser
         SqlPwd         = $SqlPwd
         }
-        
+
         PS C:\> $ImportParams = @{
         Action   = "import"
         FilePath = $BacpacFile
         }
-        
+
         PS C:\> Invoke-SqlPackage @BaseParams @ImportParams
-        
+
         This will start the sqlpackage.exe file and pass all the needed parameters.
-        
+
     .NOTES
         Author: Mötz Jensen (@splaxi)
-        
+
 #>
 function Invoke-SqlPackage {
     [CmdletBinding()]
@@ -96,19 +95,19 @@ function Invoke-SqlPackage {
     param (
         [ValidateSet("Import", "Export", "Publish")]
         [string] $Action,
-        
+
         [string] $DatabaseServer,
-        
+
         [string] $DatabaseName,
-        
+
         [string] $SqlUser,
-        
+
         [string] $SqlPwd,
-        
+
         [string] $TrustedConnection,
-        
+
         [string] $FilePath,
-        
+
         [string[]] $Properties,
 
         [string] $DiagnosticFile,
@@ -128,7 +127,7 @@ function Invoke-SqlPackage {
 
         [switch] $EnableException
     )
-              
+
     $executable = $Script:SqlPackagePath
 
     Invoke-TimeSignal -Start
@@ -161,12 +160,12 @@ function Invoke-SqlPackage {
         $null = $Params.Add("/SourceTrustServerCertificate:True")
         $null = $Params.Add("/TargetFile:`"$FilePath`"")
         $null = $Params.Add("/Properties:CommandTimeout=0")
-    
+
         if (!$UseTrustedConnection) {
             $null = $Params.Add("/SourceUser:$SqlUser")
             $null = $Params.Add("/SourcePassword:$SqlPwd")
         }
-        
+
         Remove-Item -Path $FilePath -ErrorAction SilentlyContinue -Force
     }
     elseif ($Action -eq "import") {
@@ -176,7 +175,7 @@ function Invoke-SqlPackage {
         $null = $Params.Add("/TargetTrustServerCertificate:True")
         $null = $Params.Add("/SourceFile:`"$FilePath`"")
         $null = $Params.Add("/Properties:CommandTimeout=0")
-        
+
         if (!$UseTrustedConnection) {
             $null = $Params.Add("/TargetUser:$SqlUser")
             $null = $Params.Add("/TargetPassword:$SqlPwd")
@@ -189,7 +188,7 @@ function Invoke-SqlPackage {
         $Params.Add("/TargetTrustServerCertificate:True") > $null
         $Params.Add("/SourceFile:`"$FilePath`"") > $null
         $Params.Add("/Properties:CommandTimeout=0") > $null
-        
+
         if (-not $UseTrustedConnection) {
             $Params.Add("/TargetUser:$SqlUser") > $null
             $Params.Add("/TargetPassword:$SqlPwd") > $null
@@ -208,7 +207,7 @@ function Invoke-SqlPackage {
         $Params.Add("/Diagnostics:true") > $null
         $Params.Add("/DiagnosticsFile:`"$DiagnosticFile`"") > $null
     }
-    
+
     if ($ModelFile) {
         $Params.Add("/ModelFilePath:`"$ModelFile`"") > $null
     }
@@ -217,12 +216,12 @@ function Invoke-SqlPackage {
         $Params.Add("/MaxParallelism:$MaxParallelism") > $null
     }
 
-    $result = Invoke-Process -Path $executable -Params "/Version" 
+    $result = Invoke-Process -Path $executable -Params "/Version"
     $version = $result.stdout -replace "`r`n", ""
     Write-PSFMessage -Level Verbose -Message "Using SQLPackage version $version"
 
     Invoke-Process -Executable $executable -Params $params -ShowOriginalProgress:$ShowOriginalProgress -OutputCommandOnly:$OutputCommandOnly -LogPath $LogPath
-    
+
     if (Test-PSFFunctionInterrupt) {
         Write-PSFMessage -Level Critical -Message "The SqlPackage.exe exited with an error."
         Stop-PSFFunction -Message "Stopping because of errors." -StepsUpward 1

--- a/d365fo.tools/tests/functions/Invoke-D365InstallSqlPackage.Tests.ps1
+++ b/d365fo.tools/tests/functions/Invoke-D365InstallSqlPackage.Tests.ps1
@@ -8,7 +8,7 @@
 	
 	Describe "Ensuring unchanged command signature" {
 		It "should have the expected parameter sets" {
-			(Get-Command Invoke-D365InstallSqlPackage).ParameterSets.Name | Should -Be '__AllParameterSets'
+			(Get-Command Invoke-D365InstallSqlPackage).ParameterSets.Name | Should -Be 'ImportUrl', 'ImportLatest'
 		}
 		
 		It 'Should have the expected parameter Path' {
@@ -16,46 +16,58 @@
 			$parameter.Name | Should -Be 'Path'
 			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
-			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ImportLatest', 'ImportUrl'
+			$parameter.ParameterSets.Keys | Should -Contain 'ImportLatest'
+			$parameter.ParameterSets['ImportLatest'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ImportLatest'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Contain 'ImportUrl'
+			$parameter.ParameterSets['ImportUrl'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ImportUrl'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].ValueFromRemainingArguments | Should -Be $False
 		}
-		It 'Should have the expected parameter SkipExtractFromPage' {
-			$parameter = (Get-Command Invoke-D365InstallSqlPackage).Parameters['SkipExtractFromPage']
-			$parameter.Name | Should -Be 'SkipExtractFromPage'
+		It 'Should have the expected parameter Latest' {
+			$parameter = (Get-Command Invoke-D365InstallSqlPackage).Parameters['Latest']
+			$parameter.Name | Should -Be 'Latest'
 			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
-			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ImportLatest'
+			$parameter.ParameterSets.Keys | Should -Contain 'ImportLatest'
+			$parameter.ParameterSets['ImportLatest'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ImportLatest'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ImportLatest'].ValueFromRemainingArguments | Should -Be $False
 		}
 		It 'Should have the expected parameter Url' {
 			$parameter = (Get-Command Invoke-D365InstallSqlPackage).Parameters['Url']
 			$parameter.Name | Should -Be 'Url'
 			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
-			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 1
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ImportUrl'
+			$parameter.ParameterSets.Keys | Should -Contain 'ImportUrl'
+			$parameter.ParameterSets['ImportUrl'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ImportUrl'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ImportUrl'].ValueFromRemainingArguments | Should -Be $False
 		}
 	}
 	
-	Describe "Testing parameterset __AllParameterSets" {
+	Describe "Testing parameterset ImportUrl" {
 		<#
-		__AllParameterSets -
-		__AllParameterSets -Path -SkipExtractFromPage -Url
+		ImportUrl -
+		ImportUrl -Path -Url
+		#>
+	}
+ 	Describe "Testing parameterset ImportLatest" {
+		<#
+		ImportLatest -
+		ImportLatest -Path -Latest
 		#>
 	}
 

--- a/docs/Invoke-D365InstallSqlPackage.md
+++ b/docs/Invoke-D365InstallSqlPackage.md
@@ -12,16 +12,18 @@ Download SqlPackage.exe to your machine
 
 ## SYNTAX
 
+### ImportUrl (Default)
 ```
-Invoke-D365InstallSqlPackage [[-Path] <String>] [-SkipExtractFromPage] [[-Url] <String>] [<CommonParameters>]
+Invoke-D365InstallSqlPackage [-Path <String>] [-Url <String>] [<CommonParameters>]
+```
+
+### ImportLatest
+```
+Invoke-D365InstallSqlPackage [-Path <String>] [-Latest] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Download and extract the DotNet/.NET core x64 edition of the SqlPackage.exe to your machine
-
-It parses the raw html page and tries to extract the latest download link.
-As of 12th April 2022, no .NET Core link is available on the download page.
-The cmdlet will always use the Url parameter.
+Download and extract SqlPackage.exe to your machine.
 
 ## EXAMPLES
 
@@ -30,9 +32,8 @@ The cmdlet will always use the Url parameter.
 Invoke-D365InstallSqlPackage
 ```
 
-This will download and extract the latest SqlPackage.exe.
+This will download and extract SqlPackage.exe.
 It will use the default value for the Path parameter, for where to save the SqlPackage.exe.
-It will try to extract the latest download URL from the RAW html page.
 It will update the path for the SqlPackage.exe in configuration.
 
 ### EXAMPLE 2
@@ -40,27 +41,26 @@ It will update the path for the SqlPackage.exe in configuration.
 Invoke-D365InstallSqlPackage -Path "C:\temp\SqlPackage"
 ```
 
-This will download and extract the latest SqlPackage.exe.
-It will try to extract the latest download URL from the RAW html page.
+This will download and extract SqlPackage.exe.
+It will save the SqlPackage.exe to "C:\temp\SqlPackage".
 It will update the path for the SqlPackage.exe in configuration.
 
 ### EXAMPLE 3
 ```
-Invoke-D365InstallSqlPackage -SkipExtractFromPage
+Invoke-D365InstallSqlPackage -Latest
 ```
 
 This will download and extract the latest SqlPackage.exe.
-It will rely on the Url parameter to based the download from.
-It will use the default value of the Url parameter.
+It will use https://aka.ms/sqlpackage-windows as the download URL.
 It will update the path for the SqlPackage.exe in configuration.
 
 ### EXAMPLE 4
 ```
-Invoke-D365InstallSqlPackage -SkipExtractFromPage -Url "https://go.microsoft.com/fwlink/?linkid=3030303"
+Invoke-D365InstallSqlPackage -Url "https://go.microsoft.com/fwlink/?linkid=3030303"
 ```
 
-This will download and extract the latest SqlPackage.exe.
-It will rely on the Url parameter to based the download from.
+This will download and extract SqlPackage.exe.
+It will rely on the Url parameter to base the download on.
 It will use the "https://go.microsoft.com/fwlink/?linkid=3030303" as value for the Url parameter.
 It will update the path for the SqlPackage.exe in configuration.
 
@@ -77,18 +77,18 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: Named
 Default value: C:\temp\d365fo.tools\SqlPackage
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -SkipExtractFromPage
-Instruct the cmdlet to skip trying to parse the download page and to rely on the Url parameter only
+### -Latest
+Overrides the Url parameter and uses the latest download URL provided by the evergreen link https://aka.ms/sqlpackage-windows
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: ImportLatest
 Aliases:
 
 Required: False
@@ -99,22 +99,20 @@ Accept wildcard characters: False
 ```
 
 ### -Url
-Url/Uri to where the latest SqlPackage download is located
+Url/Uri to where the SqlPackage download is located
 
-The default value is for v19.1 (16.0.6161.0) as of writing.
-This is the last version of SqlPackage based on .NET Core.
-According to the Microsoft documentation, a .NET Core version of SqlPackage should be used.
-https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/database/import-database
-Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/issues/708
+The default value is for version 162.2.111.2 as of writing.
+
+Further discussion can be found here: https://github.com/d365collaborative/d365fo.tools/discussions/816
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ImportUrl
 Aliases:
 
 Required: False
-Position: 2
-Default value: Https://go.microsoft.com/fwlink/?linkid=2196334
+Position: Named
+Default value: Https://go.microsoft.com/fwlink/?linkid=2261576
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -128,5 +126,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 Author: Mötz Jensen (@Splaxi)
+Author: Florian Hopfner (@FH-Inway)
 
 ## RELATED LINKS

--- a/wiki/Call-Internal-Functions.md
+++ b/wiki/Call-Internal-Functions.md
@@ -1,0 +1,53 @@
+# Call internal functions
+
+d365fo.tools has a number of internal functions that are used by the cmdlets. These functions are not intended to be used directly by the user and as such cannot be called directly. However, for troubleshooting purposes or when developing cmdlets, it can be useful to call these functions directly.
+
+> ⚠️ **Warning** If you follow these instructions to call internal functions, we assume you know what you are doing and have taken precautions against an internal function call going wrong.
+
+## Dot source the internal function
+
+To call an internal function, you need to [dot source](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_scripts?view=powershell-5.1#script-scope-and-dot-sourcing) the function. This is done by using the `.` operator followed by the path to the function. 
+
+The path to the function consists of 3 parts:
+1. **The path to the module**: If you have installed the module, you can use the following PowerShell command to get the path to the module:
+    ```powershell
+    Split-Path $(Get-Module d365fo.tools -ListAvailable | Select-Object -First 1).Path
+    ```
+    This will return the path to the module, which is typically something like `C:\Program Files\WindowsPowerShell\Modules\d365fo.tools\` followed by a version number.
+2. **The path to the function**: Within the module, the internal functions are located in the `internal\functions` folder.
+3. **The file name of the function**: The file name of the function is the name of the function you want to call, followed by `.ps1`.
+
+For example, to dot source the internal function `Invoke-Process` you would use a command similar to the following:
+```
+. 'C:\Program Files\WindowsPowerShell\Modules\d365fo.tools\0.7.9\internal\functions\Invoke-Process.ps1'
+```
+
+## Call the internal function
+
+Once you have dot sourced the internal function, you can call it as you would any other function. For example, to call the `Invoke-Process` function, you would use a command similar to the following:
+
+```powershell
+Invoke-Process -Path 'C:\Temp\Program.exe' -Params '/help'
+```
+
+## Dependencies
+
+Internal functions may have dependencies on other internal functions, cmdlets or settings. If you are calling an internal function that has dependencies, you will need to dot source and initialize the dependencies as well.
+
+This may require calling the function multiple times. Each time, the error messages should help you identify which dependencies are missing.
+
+For example, the `Invoke-Process` function has the following dependencies:
+- internal function `Invoke-TimeSignal`
+- internal function `Test-PathExists`
+- setting `$Script:TimeSignals`
+
+So to fully load the `Invoke-Process` function, you would use the following script:
+
+```powershell
+. 'C:\Program Files\WindowsPowerShell\Modules\d365fo.tools\0.7.9\internal\functions\Invoke-TimeSignal.ps1'
+. 'C:\Program Files\WindowsPowerShell\Modules\d365fo.tools\0.7.9\internal\functions\Test-PathExists.ps1'
+. 'C:\Program Files\WindowsPowerShell\Modules\d365fo.tools\0.7.9\internal\functions\Invoke-Process.ps1'
+$Script:TimeSignals = @{}
+```
+
+> ℹ️ **Note** The dependencies of an internal function may have dependencies of their own.


### PR DESCRIPTION
This updates the default version of SqlPackage that d365fo.tools installs to 162.2.111.2 (the first .NET 8 version).

In addition, it replaces the `-SkipExtractFromPage` parameter and the corresponding web scraping logic with the `-Latest` parameter and the evergreen link https://aka.ms/sqlpackage-windows

Note that unlike the behavior from when the web scraping logic was still working, the latest version of SqlPackage is NOT installed by default. Instead, the fixed version 162.2.111.2 is installed (which may be updated to later versions in the future). Reasons for this change in behavior are discussed in #747.

The changes also include
- giving `Invoke-Process` a return value with the standard and error output
- `Invoke-D365InstallSqlPackage` and `Invoke-SqlPackage` make use of that output to provide information on the SqlPackage version
- documentation on how to call internal functions of d365fo.tools