### PR TITLE
Bugfix for Issue 839: File Description not correctly set in LCS Asset upload

### DIFF
--- a/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
+++ b/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
@@ -95,7 +95,8 @@ function Start-LcsUploadV2 {
     [Cmdletbinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string] $Token,
+        [Alias('Token')]
+        [string] $BearerToken,
 
         [Parameter(Mandatory = $true)]
         [int] $ProjectId,

--- a/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
+++ b/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
@@ -6,8 +6,8 @@
     .DESCRIPTION
         Start the flow of actions to upload a file to LCS
         
-    .PARAMETER Token
-        The token to be used for the http request against the LCS API
+    .PARAMETER BearerToken
+        The token you want to use when working against the LCS api
         
     .PARAMETER ProjectId
         The project id for the Dynamics 365 for Finance & Operations project inside LCS

--- a/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
+++ b/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
@@ -120,18 +120,11 @@ function Start-LcsUploadV2 {
     begin {
         Invoke-TimeSignal -Start
         
-        if ($Description) {
-            $jsonDescription = $Description
-        }
-        else {
-            $jsonDescription = $null
-        }
-
         $fileTypeValue = [int]$FileType
         $jsonPayload = @{
             Name            = $Name
             FileName        = $Filename
-            FileDescription = $jsonDescription
+            FileDescription = $Description
             SizeByte        = 0
             FileType        = $fileTypeValue
         } | ConvertTo-Json

--- a/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
+++ b/d365fo.tools/internal/functions/start-lcsuploadv2.ps1
@@ -119,6 +119,13 @@ function Start-LcsUploadV2 {
     begin {
         Invoke-TimeSignal -Start
         
+        if ($Description) {
+            $jsonDescription = $Description
+        }
+        else {
+            $jsonDescription = $null
+        }
+
         $fileTypeValue = [int]$FileType
         $jsonPayload = @{
             Name            = $Name


### PR DESCRIPTION
Quick fix for missing $jsonDescription and correcting the token parameter.