### PR TITLE
:bug: Fix Get-D365AzureStorageFile

### DIFF
--- a/d365fo.tools/bin/d365fo.tools-index.json
+++ b/d365fo.tools/bin/d365fo.tools-index.json
@@ -1778,7 +1778,7 @@
     },
     {
         "CommandName":  "Get-D365AzureStorageFile",
-        "Description":  "Get all files from an Azure Storage Account",
+        "Description":  "Get information for files from an Azure Storage Account",
         "Tags":  [
                      "Azure",
                      "Azure Storage",
@@ -1790,7 +1790,7 @@
         "Params":  [
                        [
                            "AccountId",
-                           "Storage Account Name / Storage Account Id where you want to look for files",
+                           "Storage Account Name / Storage Account Id where file information should be retrieved from",
                            "",
                            false,
                            "false",
@@ -1806,7 +1806,7 @@
                        ],
                        [
                            "SAS",
-                           "The SAS key that you have created for the storage account or blob container",
+                           "The SAS key for the storage account or blob container",
                            "",
                            false,
                            "false",
@@ -1814,7 +1814,7 @@
                        ],
                        [
                            "Container",
-                           "Name of the blob container inside the storage account you want to look for files",
+                           "Name of the blob container inside the storage account where file information should be retrieved from",
                            "Blobname,Blob",
                            false,
                            "false",
@@ -1822,7 +1822,7 @@
                        ],
                        [
                            "Name",
-                           "Name of the file you are looking for\nAccepts wildcards for searching. E.g. -Name \"Application*Adaptor\"\nDefault value is \"*\" which will search for all packages",
+                           "Name of the files information should be retrieved for\nAccepts wildcards for searching. E.g. -Name \"Application*Adaptor\"\nDefault value is \"*\" which will search for all files",
                            "FileName",
                            false,
                            "false",
@@ -1830,7 +1830,7 @@
                        ],
                        [
                            "Latest",
-                           "Instruct the cmdlet to only fetch the latest file from the Azure Storage Account",
+                           "Instruct the cmdlet to only fetch the information of the latest file from the Azure Storage Account",
                            "GetLatest",
                            true,
                            "false",
@@ -1839,10 +1839,10 @@
                    ],
         "Alias":  "",
         "Author":  "Mötz Jensen (@Splaxi)",
-        "Synopsis":  "Get a file from Azure",
+        "Synopsis":  "Get file information from Azure Storage",
         "Name":  "Get-D365AzureStorageFile",
         "Links":  null,
-        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\"\nThis will get all files in the blob container \"backupfiles\".\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access.\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\" -Latest\nThis will get the latest (newest) file from the blob container \"backupfiles\".\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access to the container.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\" -Name \"*UAT*\"\nThis will get all files in the blob container \"backupfiles\" that fits the \"*UAT*\" search value.\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access to the container.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -SAS \"sv2018-03-28\u0026siunlisted\u0026src\u0026sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk\" -Container \"backupfiles\" -Latest\nThis will get the latest (newest) file from the blob container \"backupfiles\".\r\nIt will use the SAS key \"sv2018-03-28\u0026siunlisted\u0026src\u0026sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk\" to gain access to the container.",
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\"\nThis will get information for all files in the blob container \"backupfiles\".\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access.\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\" -Latest\nThis will get information for the latest (newest) file from the blob container \"backupfiles\".\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access to the container.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" -Container \"backupfiles\" -Name \"*UAT*\"\nThis will get information for all files in the blob container \"backupfiles\" that fits the \"*UAT*\" search value.\r\nIt will use the AccessToken \"xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51\" to gain access to the container.\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eGet-D365AzureStorageFile -AccountId \"miscfiles\" -SAS \"sv2018-03-28\u0026siunlisted\u0026src\u0026sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk\" -Container \"backupfiles\" -Latest\nThis will get information for the latest (newest) file from the blob container \"backupfiles\".\r\nIt will use the SAS key \"sv2018-03-28\u0026siunlisted\u0026src\u0026sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk\" to gain access to the container.",
         "Syntax":  "Get-D365AzureStorageFile [-AccountId \u003cString\u003e] [-AccessToken \u003cString\u003e] [-SAS \u003cString\u003e] [-Container \u003cString\u003e] [-Name \u003cString\u003e] [\u003cCommonParameters\u003e]\nGet-D365AzureStorageFile [-AccountId \u003cString\u003e] [-AccessToken \u003cString\u003e] [-SAS \u003cString\u003e] [-Container \u003cString\u003e] -Latest [\u003cCommonParameters\u003e]"
     },
     {

--- a/d365fo.tools/functions/get-d365azurestoragefile.ps1
+++ b/d365fo.tools/functions/get-d365azurestoragefile.ps1
@@ -103,7 +103,7 @@ function Get-D365AzureStorageFile {
     }
 
     try {
-        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | 
+        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext |
             Sort-Object -Descending { $_.LastModified }
 
         $selectParams = @{
@@ -111,8 +111,8 @@ function Get-D365AzureStorageFile {
             Property = "Name", "Length as Size to PSFSize", "LastModified"
         }
         if ($Latest) {
-            $files | 
-                Select-Object -First 1 | 
+            $files |
+                Select-Object -First 1 |
                 Select-PSFObject @selectParams
         }
         else {

--- a/d365fo.tools/functions/get-d365azurestoragefile.ps1
+++ b/d365fo.tools/functions/get-d365azurestoragefile.ps1
@@ -1,61 +1,62 @@
 ﻿
 <#
     .SYNOPSIS
-        Get a file from Azure
+        Get file information from Azure Storage
         
     .DESCRIPTION
-        Get all files from an Azure Storage Account
+        Get information for files from an Azure Storage Account
         
     .PARAMETER AccountId
-        Storage Account Name / Storage Account Id where you want to look for files
+        Storage Account Name / Storage Account Id where file information should be retrieved from
         
     .PARAMETER AccessToken
         The token that has the needed permissions for the search action
         
     .PARAMETER SAS
-        The SAS key that you have created for the storage account or blob container
+        The SAS key for the storage account or blob container
         
     .PARAMETER Container
-        Name of the blob container inside the storage account you want to look for files
+        Name of the blob container inside the storage account where file information should be retrieved from
         
     .PARAMETER Name
-        Name of the file you are looking for
+        Name of the files information should be retrieved for
         
         Accepts wildcards for searching. E.g. -Name "Application*Adaptor"
         
-        Default value is "*" which will search for all packages
+        Default value is "*" which will search for all files
         
     .PARAMETER Latest
-        Instruct the cmdlet to only fetch the latest file from the Azure Storage Account
+        Instruct the cmdlet to only fetch the information of the latest file from the Azure Storage Account
         
     .EXAMPLE
         PS C:\> Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles"
         
-        This will get all files in the blob container "backupfiles".
+        This will get information for all files in the blob container "backupfiles".
         It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access.
         
     .EXAMPLE
         PS C:\> Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles" -Latest
         
-        This will get the latest (newest) file from the blob container "backupfiles".
+        This will get information for the latest (newest) file from the blob container "backupfiles".
         It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access to the container.
         
     .EXAMPLE
         PS C:\> Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles" -Name "*UAT*"
         
-        This will get all files in the blob container "backupfiles" that fits the "*UAT*" search value.
+        This will get information for all files in the blob container "backupfiles" that fits the "*UAT*" search value.
         It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access to the container.
         
     .EXAMPLE
         PS C:\> Get-D365AzureStorageFile -AccountId "miscfiles" -SAS "sv2018-03-28&siunlisted&src&sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk" -Container "backupfiles" -Latest
         
-        This will get the latest (newest) file from the blob container "backupfiles".
+        This will get information for the latest (newest) file from the blob container "backupfiles".
         It will use the SAS key "sv2018-03-28&siunlisted&src&sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk" to gain access to the container.
         
     .NOTES
         Tags: Azure, Azure Storage, Token, Blob, File, Container
         
         Author: Mötz Jensen (@Splaxi)
+        Author: Florian Hopfner (@FH-Inway)
 #>
 function Get-D365AzureStorageFile {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -79,9 +80,9 @@ function Get-D365AzureStorageFile {
         [switch] $Latest
     )
 
-    if (([string]::IsNullOrEmpty($AccountId) -eq $true) -or
-        ([string]::IsNullOrEmpty($Container)) -or
-        (([string]::IsNullOrEmpty($AccessToken)) -and ([string]::IsNullOrEmpty($SAS)))) {
+    $connectionInformation = ($AccountId -and $Container)
+    $authenticationInformation = ($AccessToken -or $SAS)
+    if (-not ($connectionInformation -and $authenticationInformation)) {
         Write-PSFMessage -Level Host -Message "It seems that you are missing some of the parameters. Please make sure that you either supplied them or have the right configuration saved."
         Stop-PSFFunction -Message "Stopping because of missing parameters"
         return
@@ -102,21 +103,28 @@ function Get-D365AzureStorageFile {
     }
 
     try {
-        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.LastModified }
+        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | 
+            Sort-Object -Descending { $_.LastModified }
 
+        $selectParams = @{
+            TypeName = "D365FO.TOOLS.Azure.Blob"
+            Property = "Name", "Length as Size to PSFSize", "LastModified"
+        }
         if ($Latest) {
-            $files | Select-Object -First 1 | Select-PSFObject -TypeName D365FO.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }
+            $files | 
+                Select-Object -First 1 | 
+                Select-PSFObject @selectParams
         }
         else {
-    
-            foreach ($obj in $files) {
-                if ($obj.Name -NotLike $Name) { continue }
-
-                $obj | Select-PSFObject -TypeName D365FO.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }
+            $filteredFiles = $files | Where-Object { $_.Name -Like $Name }
+            foreach ($fileInfo in $filteredFiles) {
+                $fileInfo | Select-PSFObject @selectParams
             }
         }
     }
     catch {
         Write-PSFMessage -Level Warning -Message "Something broke" -ErrorRecord $_
     }
+
+    Invoke-TimeSignal -End
 }

--- a/d365fo.tools/functions/get-d365azurestoragefile.ps1
+++ b/d365fo.tools/functions/get-d365azurestoragefile.ps1
@@ -102,7 +102,7 @@ function Get-D365AzureStorageFile {
     }
 
     try {
-        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.Properties.LastModified }
+        $files = Get-AzStorageBlob -Container $($Container.ToLower()) -Context $storageContext | Sort-Object -Descending { $_.LastModified }
 
         if ($Latest) {
             $files | Select-Object -First 1 | Select-PSFObject -TypeName D365FO.TOOLS.Azure.Blob "name", @{Name = "Size"; Expression = { [PSFSize]$_.Length } }, @{Name = "LastModified"; Expression = { [Datetime]::Parse($_.LastModified) } }

--- a/docs/Get-D365AzureStorageFile.md
+++ b/docs/Get-D365AzureStorageFile.md
@@ -8,7 +8,7 @@ schema: 2.0.0
 # Get-D365AzureStorageFile
 
 ## SYNOPSIS
-Get a file from Azure
+Get file information from Azure Storage
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Get-D365AzureStorageFile [-AccountId <String>] [-AccessToken <String>] [-SAS <St
 ```
 
 ## DESCRIPTION
-Get all files from an Azure Storage Account
+Get information for files from an Azure Storage Account
 
 ## EXAMPLES
 
@@ -34,7 +34,7 @@ Get all files from an Azure Storage Account
 Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles"
 ```
 
-This will get all files in the blob container "backupfiles".
+This will get information for all files in the blob container "backupfiles".
 It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access.
 
 ### EXAMPLE 2
@@ -42,7 +42,7 @@ It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34x
 Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles" -Latest
 ```
 
-This will get the latest (newest) file from the blob container "backupfiles".
+This will get information for the latest (newest) file from the blob container "backupfiles".
 It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access to the container.
 
 ### EXAMPLE 3
@@ -50,7 +50,7 @@ It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34x
 Get-D365AzureStorageFile -AccountId "miscfiles" -AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" -Container "backupfiles" -Name "*UAT*"
 ```
 
-This will get all files in the blob container "backupfiles" that fits the "*UAT*" search value.
+This will get information for all files in the blob container "backupfiles" that fits the "*UAT*" search value.
 It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34xxxxx51" to gain access to the container.
 
 ### EXAMPLE 4
@@ -58,13 +58,13 @@ It will use the AccessToken "xx508xx63817x752xx74004x30705xx92x58349x5x78f5xx34x
 Get-D365AzureStorageFile -AccountId "miscfiles" -SAS "sv2018-03-28&siunlisted&src&sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk" -Container "backupfiles" -Latest
 ```
 
-This will get the latest (newest) file from the blob container "backupfiles".
+This will get information for the latest (newest) file from the blob container "backupfiles".
 It will use the SAS key "sv2018-03-28&siunlisted&src&sigAUOpdsfpoWE976ASDhfjkasdf(5678sdfhk" to gain access to the container.
 
 ## PARAMETERS
 
 ### -AccountId
-Storage Account Name / Storage Account Id where you want to look for files
+Storage Account Name / Storage Account Id where file information should be retrieved from
 
 ```yaml
 Type: String
@@ -94,7 +94,7 @@ Accept wildcard characters: False
 ```
 
 ### -SAS
-The SAS key that you have created for the storage account or blob container
+The SAS key for the storage account or blob container
 
 ```yaml
 Type: String
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -Container
-Name of the blob container inside the storage account you want to look for files
+Name of the blob container inside the storage account where file information should be retrieved from
 
 ```yaml
 Type: String
@@ -124,13 +124,13 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Name of the file you are looking for
+Name of the files information should be retrieved for
 
 Accepts wildcards for searching.
 E.g.
 -Name "Application*Adaptor"
 
-Default value is "*" which will search for all packages
+Default value is "*" which will search for all files
 
 ```yaml
 Type: String
@@ -145,7 +145,7 @@ Accept wildcard characters: False
 ```
 
 ### -Latest
-Instruct the cmdlet to only fetch the latest file from the Azure Storage Account
+Instruct the cmdlet to only fetch the information of the latest file from the Azure Storage Account
 
 ```yaml
 Type: SwitchParameter
@@ -170,5 +170,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 Tags: Azure, Azure Storage, Token, Blob, File, Container
 
 Author: Mötz Jensen (@Splaxi)
+Author: Florian Hopfner (@FH-Inway)
 
 ## RELATED LINKS


### PR DESCRIPTION
Fixes a bug with the file sorting in `Get-D365AzureStorageFile`. Seems to be a holdover from https://github.com/d365collaborative/d365fo.tools/commit/5182b26ba0ce792751bfc70e4bc693c6ca0e3034 when the file information retrieval was refactored to use `Get-AzStorageBlob`.

Also does some code refactoring for better readability and maintainability, incorporating some suggestions by @FriedrichWeinmann in #870 