### PR TITLE
Added KillDatabaseConnection search string to RepairBacpac.Simple.json

### DIFF
--- a/d365fo.tools/internal/misc/RepairBacpac.Simple.json
+++ b/d365fo.tools/internal/misc/RepairBacpac.Simple.json
@@ -6,5 +6,9 @@
     {
         "Search": "*<Element Type=\"SqlPermissionStatement\"*ms_db_configwriter*",
         "End": "*</Element>*"
+    },
+	{
+        "Search": "*<Element Type=\"SqlPermissionStatement\"*KillDatabaseConnection*",
+        "End": "*</Element>*"
     }
 ]


### PR DESCRIPTION
Added the "KillDatabaseConnection" search string to RepairBacpac.Simple.json, to fix the issue "KILL DATABASE CONNECTION' is not supported in this version of SQL Server"

See for reference:
https://www.linkedin.com/pulse/how-fix-bacpac-import-error-kill-database-connection-supported-ahmed-0zxle/