### PR TITLE
new command to request just in time jit database access for a unified development environment ude #897

### DIFF
--- a/d365fo.tools/bin/d365fo.tools-index.json
+++ b/d365fo.tools/bin/d365fo.tools-index.json
@@ -10636,6 +10636,131 @@
         "Syntax":  "Repair-D365BacpacModelFile [-Path] \u003cString\u003e [[-OutputPath] \u003cString\u003e] [[-PathRepairSimple] \u003cString\u003e] [[-PathRepairQualifier] \u003cString\u003e] [[-PathRepairReplace] \u003cString\u003e] [-KeepFiles] [-Force] [\u003cCommonParameters\u003e]"
     },
     {
+        "CommandName":  "Request-D365DatabaseJITAccess",
+        "Description":  "Utilize the D365FO Power Platform OData API to request just in time access (JIT) to a UDE database\n\nThis will allow you to get temporary database credentials for connecting to the database directly\n\nIf no credentials are provided (ClientId/ClientSecret or Credential), the function will automatically use interactive authentication via Azure PowerShell.",
+        "Tags":  [
+                     "JIT",
+                     "Database",
+                     "Access",
+                     "UDE",
+                     "OData",
+                     "RestApi"
+                 ],
+        "Params":  [
+                       [
+                           "Url",
+                           "URL / URI for the D365FO Power Platform environment that provides the JIT access API.\nNote: This is not the URL of the D365FO environment itself (aka the Finance and Operations URL). Instead, it is the URL of the Power Platform environment (aka the Environment URL) that the D365FO \r\nenvironment is integrated with.\nFor example: \"https://operations-acme-uat.crm4.dynamics.com/\"",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "ClientId",
+                           "The ClientId obtained from the Azure Portal when you created a Registered Application",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "ClientSecretAsPlainString",
+                           "The ClientSecret obtained from the Azure Portal when you created a Registered Application\nThis is the plain text version of the ClientSecret parameter.\nEither ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "ClientSecretAsSecureString",
+                           "The ClientSecret obtained from the Azure Portal when you created a Registered Application\nThis is the secure string version of the ClientSecret parameter.\nEither ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "Credential",
+                           "The Credential object containing Username (ClientId) and Password (ClientSecret)\nThe Username will be used as ClientId\r\nThe Password will be used as ClientSecret\nEither ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "Tenant",
+                           "Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access",
+                           "",
+                           true,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "ClientIPAddress",
+                           "The IP address of the client that needs database access\nDefault value is \"127.0.0.1\" which will be replaced with the public IP address of the client as determined by querying \"https://icanhazip.com\"",
+                           "",
+                           false,
+                           "false",
+                           "127.0.0.1"
+                       ],
+                       [
+                           "Role",
+                           "The database role to assign to the JIT access\nValid options are \"Reader\" and \"Writer\"\nDefault value is \"Reader\"",
+                           "",
+                           false,
+                           "false",
+                           "Reader"
+                       ],
+                       [
+                           "Reason",
+                           "The reason for requesting JIT database access\nDefault value is \"Administrative access via d365fo.tools\"",
+                           "",
+                           false,
+                           "false",
+                           "Administrative access via d365fo.tools"
+                       ],
+                       [
+                           "SQLServerManagementStudioPath",
+                           "The full path to the SQL Server Management Studio executable (ssms.exe)\nIf provided, the function will automatically open SQL Server Management Studio and connect to the database using the obtained credentials.\nExample: \"C:\\Program Files\\Microsoft SQL Server Management Studio 21\\Release\\Common7\\IDE\\SSMS.exe\"\nNote: Since version 18, SQL Server Management Studio does no longer allow providing the password directly in the command line. The password will be copied to clipboard instead for easy pasting. It \r\nwill be cleared from clipboard after 60 seconds.\nNote: After SQL Server Management Studio has been started this way, it will display a \"Connect to the following server?\" warning dialog. Confirm it with \"Yes\". Next, because of the missing password, \r\na \"Connect to server\" error dialog will be shown. Confirm it with \"OK\". Finally, a \"Connect to server\" form will be shown where the password can be pasted and the connection be established with the \r\n\"Connect\" button. Answering \"No\" on the first warning dialog will take you directly to the \"Connect to server\" form, but the database information will not be pre-filled.\nNote: The connection may fail at first because it takes some time until the client\u0027s IP address is whitelisted in the Azure SQL Database firewall rules. If that happens, just try again after a minute \r\nor so.",
+                           "",
+                           false,
+                           "false",
+                           ""
+                       ],
+                       [
+                           "RawOutput",
+                           "Instructs the cmdlet to include the outer structure of the response received from the endpoint\nThe output will still be a PSCustomObject",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ],
+                       [
+                           "OutputAsJson",
+                           "Instructs the cmdlet to convert the output to a Json string",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ],
+                       [
+                           "EnableException",
+                           "This parameters disables user-friendly warnings and enables the throwing of exceptions\r\nThis is less user friendly, but allows catching exceptions in calling scripts\r\nUsually this parameter is not used directly, but via the Enable-D365Exception cmdlet\r\nSee https://github.com/d365collaborative/d365fo.tools/wiki/Exception-handling#what-does-the--enableexception-parameter-do for further information",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ]
+                   ],
+        "Alias":  "",
+        "Author":  "Florian Hopfner (@FH-Inway)",
+        "Synopsis":  "Request just in time (JIT) database access for a unified development environment (UDE)",
+        "Name":  "Request-D365DatabaseJITAccess",
+        "Links":  null,
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eRequest-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\"\nThis will request JIT database access for the D365FO environment using interactive authentication.\r\nIt will prompt you to sign in with your Azure AD credentials if not already signed in.\r\nIt will use the client\u0027s IP address, role \"Reader\", and reason \"Administrative access via d365fo.tools\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eRequest-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -ClientId \"dea8d7a9-1602-4429-b138-111111111111\" \r\n-ClientSecretAsPlainString \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\"\nThis will request JIT database access for the D365FO environment.\r\nIt will use the client\u0027s IP address, role \"Reader\", and reason \"Administrative access via d365fo.tools\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the \"https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token\" url with the specified Tenant parameter: \r\n\"e674da86-7ee5-40a7-b777-1111111111111\".\r\nIt will authenticate with the specified ClientId parameter: \"dea8d7a9-1602-4429-b138-111111111111\".\r\nIt will authenticate with the specified ClientSecretAsPlainString parameter: \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\".\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eRequest-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -ClientId \"dea8d7a9-1602-4429-b138-111111111111\" \r\n-ClientSecretAsPlainString \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\" -ClientIPAddress \"192.168.1.100\" -Role \"Writer\" -Reason \"Development work\"\nThis will request JIT database access for the D365FO environment with Writer privileges.\r\nIt will use the client IP address \"192.168.1.100\", role \"Writer\", and reason \"Development work\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".\r\nIt will authenticate with the specified ClientId parameter: \"dea8d7a9-1602-4429-b138-111111111111\".\r\nIt will authenticate with the specified ClientSecretAsPlainString parameter: \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\".\n-------------------------- EXAMPLE 4 --------------------------\nPS C:\\\u003eRequest-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -ClientId \"dea8d7a9-1602-4429-b138-111111111111\" \r\n-ClientSecretAsPlainString \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\" -OutputAsJson\nThis will request JIT database access for the D365FO environment and display the result as json.\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".\r\nIt will authenticate with the specified ClientId parameter: \"dea8d7a9-1602-4429-b138-111111111111\".\r\nIt will authenticate with the specified ClientSecretAsPlainString parameter: \"Vja/VmdxaLOPR+alkjfsadffelkjlfw234522\".\n-------------------------- EXAMPLE 5 --------------------------\nPS C:\\\u003e$clientSecretSecure = Read-Host -AsSecureString \"Enter the Client Secret\"\nPS C:\\\u003e Request-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -ClientId \"dea8d7a9-1602-4429-b138-111111111111\" \r\n-ClientSecretAsSecureString $clientSecretSecure\nThis will prompt the user to enter the client secret securely (the input will be masked).\r\nThen it will request JIT database access for the D365FO environment using the secure string for authentication.\r\nIt will use the client\u0027s IP address, role \"Reader\", and reason \"Administrative access via d365fo.tools\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".\r\nIt will authenticate with the specified ClientId parameter: \"dea8d7a9-1602-4429-b138-111111111111\".\r\nIt will authenticate with the client secret provided through the secure prompt.\n-------------------------- EXAMPLE 6 --------------------------\nPS C:\\\u003e$credential = Get-Credential -UserName \"dea8d7a9-1602-4429-b138-111111111111\" -Message \"Enter the Client Secret\"\nPS C:\\\u003e Request-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -Credential $credential\nThis will prompt the user to enter the client secret through a secure credential dialog (using the ClientId as the username).\r\nThen it will request JIT database access for the D365FO environment using the credential for authentication.\r\nIt will use the client\u0027s IP address, role \"Reader\", and reason \"Administrative access via d365fo.tools\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".\r\nIt will authenticate with the client id and secret provided through the credential object.\n-------------------------- EXAMPLE 7 --------------------------\nPS C:\\\u003eRequest-D365DatabaseJITAccess -Url \"https://operations-acme-uat.crm4.dynamics.com/\" -Tenant \"e674da86-7ee5-40a7-b777-1111111111111\" -SQLServerManagementStudioPath \"C:\\Program Files\\Microsoft \r\nSQL Server Management Studio 21\\Release\\Common7\\IDE\\SSMS.exe\"\nThis will request JIT database access for the D365FO environment using interactive authentication.\r\nIt will open SQL Server Management Studio and connect to the database using the obtained credentials.\r\nIt will use the client\u0027s IP address, role \"Reader\", and reason \"Administrative access via d365fo.tools\".\r\nIt will contact the D365FO instance specified in the Url parameter: \"https://operations-acme-uat.crm4.dynamics.com/\".\r\nIt will authenticate against the Azure Active Directory with the specified Tenant parameter: \"e674da86-7ee5-40a7-b777-1111111111111\".",
+        "Syntax":  "Request-D365DatabaseJITAccess -Url \u003cString\u003e -Tenant \u003cString\u003e [-ClientIPAddress \u003cString\u003e] [-Role \u003cString\u003e] [-Reason \u003cString\u003e] [-SQLServerManagementStudioPath \u003cString\u003e] [-RawOutput] [-OutputAsJson] [-EnableException] [\u003cCommonParameters\u003e]\nRequest-D365DatabaseJITAccess -Url \u003cString\u003e -ClientId \u003cString\u003e -ClientSecretAsSecureString \u003cSecureString\u003e -Tenant \u003cString\u003e [-ClientIPAddress \u003cString\u003e] [-Role \u003cString\u003e] [-Reason \u003cString\u003e] [-SQLServerManagementStudioPath \u003cString\u003e] [-RawOutput] [-OutputAsJson] [-EnableException] [\u003cCommonParameters\u003e]\nRequest-D365DatabaseJITAccess -Url \u003cString\u003e -ClientId \u003cString\u003e -ClientSecretAsPlainString \u003cString\u003e -Tenant \u003cString\u003e [-ClientIPAddress \u003cString\u003e] [-Role \u003cString\u003e] [-Reason \u003cString\u003e] [-SQLServerManagementStudioPath \u003cString\u003e] [-RawOutput] [-OutputAsJson] [-EnableException] [\u003cCommonParameters\u003e]\nRequest-D365DatabaseJITAccess -Url \u003cString\u003e -Credential \u003cPSCredential\u003e -Tenant \u003cString\u003e [-ClientIPAddress \u003cString\u003e] [-Role \u003cString\u003e] [-Reason \u003cString\u003e] [-SQLServerManagementStudioPath \u003cString\u003e] [-RawOutput] [-OutputAsJson] [-EnableException] [\u003cCommonParameters\u003e]"
+    },
+    {
         "CommandName":  "Restart-D365Environment",
         "Description":  "Restart the different services in a Dynamics 365 Finance \u0026 Operations environment",
         "Tags":  [

--- a/d365fo.tools/d365fo.tools.psd1
+++ b/d365fo.tools/d365fo.tools.psd1
@@ -272,6 +272,8 @@
 		'Remove-D365Model',
 		'Remove-D365User',
 
+		'Request-D365DatabaseJITAccess',
+
 		'Rename-D365Instance',
 		'Rename-D365ComputerName',
 

--- a/d365fo.tools/functions/request-d365databasejitaccess.ps1
+++ b/d365fo.tools/functions/request-d365databasejitaccess.ps1
@@ -1,0 +1,190 @@
+﻿
+<#
+    .SYNOPSIS
+        Request just in time (JIT) database access for a unified development environment (UDE)
+        
+    .DESCRIPTION
+        Utilize the D365FO OData API to request just in time access (JIT) to a UDE database
+        
+        This will allow you to get temporary database credentials for connecting to the database directly
+        
+    .PARAMETER Url
+        URL / URI for the D365FO environment you want to access
+        
+        If you are working against a D365FO instance, it will be the URL / URI for the instance itself
+        
+        This should be the full URL, e.g. "https://operations-acme-uat.crm4.dynamics.com/"
+        
+    .PARAMETER ClientId
+        The ClientId obtained from the Azure Portal when you created a Registered Application
+        
+    .PARAMETER ClientSecret
+        The ClientSecret obtained from the Azure Portal when you created a Registered Application
+        
+    .PARAMETER Tenant
+        Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access
+        
+    .PARAMETER ClientIPAddress
+        The IP address of the client that needs database access
+        
+        Default value is "127.0.0.1" for localhost access
+        
+    .PARAMETER Role
+        The database role to assign to the JIT access
+        
+        Valid options are "Reader" and "Writer"
+        
+        Default value is "Reader"
+        
+    .PARAMETER Reason
+        The reason for requesting JIT database access
+        
+        This is logged for audit purposes
+        
+        Default value is "Administrative access via d365fo.tools"
+        
+    .PARAMETER RawOutput
+        Instructs the cmdlet to include the outer structure of the response received from the endpoint
+        
+        The output will still be a PSCustomObject
+        
+    .PARAMETER OutputAsJson
+        Instructs the cmdlet to convert the output to a Json string
+        
+    .EXAMPLE
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
+        
+        This will request JIT database access for the D365FO environment.
+        It will use the default client IP address "127.0.0.1", role "Reader", and reason "Administrative access via d365fo.tools".
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        
+    .EXAMPLE
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
+        
+        This will request JIT database access for the D365FO environment with Writer privileges.
+        It will use the client IP address "192.168.1.100", role "Writer", and reason "Development work".
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        
+    .EXAMPLE
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
+        
+        This will request JIT database access for the D365FO environment and display the result as json.
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        
+    .NOTES
+        Tags: JIT, Database, Access, UDE, OData, RestApi
+        
+        Author: Mötz Jensen (@Splaxi)
+        
+        This cmdlet is inspired by the PowerShell script provided in GitHub issue for d365fo.tools
+        
+#>
+function Request-D365DatabaseJITAccess {
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string] $Url,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ClientId,
+
+        [Parameter(Mandatory = $true)]
+        [string] $ClientSecret,
+
+        [Parameter(Mandatory = $true)]
+        [string] $Tenant,
+
+        [string] $ClientIPAddress = "127.0.0.1",
+
+        [ValidateSet("Reader", "Writer")]
+        [string] $Role = "Reader",
+
+        [string] $Reason = "Administrative access via d365fo.tools",
+
+        [switch] $RawOutput,
+
+        [switch] $OutputAsJson
+    )
+
+    begin {
+        # Clean up the URL to ensure it ends with a slash
+        if (-not $Url.EndsWith('/')) {
+            $Url = $Url + '/'
+        }
+    }
+
+    process {
+        $bearerParms = @{
+            Resource        = $Url
+            ClientId        = $ClientId
+            ClientSecret    = $ClientSecret
+            AuthProviderUri = "https://login.microsoftonline.com/$Tenant/oauth2/token"
+        }
+
+        $bearer = Invoke-ClientCredentialsGrant @bearerParms | Get-BearerToken
+
+        $headers = @{
+            'Authorization' = $bearer
+            'Accept'        = 'application/json'
+            'Content-Type'  = 'application/json; charset=utf-8'
+        }
+
+        $requestUrl = $Url + "api/data/v9.2/msprov_getfinopssqljitaccessasync"
+
+        $body = @{
+            "sqljitclientipaddress" = $ClientIPAddress
+            "sqljitreason"          = $Reason
+            "sqljitrole"            = $Role
+        } | ConvertTo-Json -Depth 3
+
+        try {
+            Write-PSFMessage -Level Verbose -Message "Requesting JIT database access from endpoint: $requestUrl"
+            Write-PSFMessage -Level Verbose -Message "Request body: $body"
+
+            $response = Invoke-RestMethod -Uri $requestUrl -Method Post -Headers $headers -Body $body
+
+            if ($RawOutput) {
+                $result = $response
+            }
+            else {
+                # Extract the relevant information from the response
+                $result = [PSCustomObject]@{
+                    Username         = $response.sqljitusername
+                    Password         = $response.sqljitpassword
+                    ServerName       = $response.servername
+                    DatabaseName     = $response.databasename
+                    DatabaseType     = $response.databasetype
+                    IPAddress        = $response.ipaddress
+                    Role             = $response.sqljitrole
+                    ExpirationTime   = $response.sqljitexpiration
+                    OperationId      = $response.operationhistoryid
+                }
+            }
+
+            if ($OutputAsJson) {
+                $result | ConvertTo-Json -Depth 10
+            }
+            else {
+                $result
+            }
+        }
+        catch {
+            Write-PSFMessage -Level Host -Message "Something went wrong while requesting JIT database access" -Exception $PSItem.Exception
+            Stop-PSFFunction -Message "Stopping because of errors" -StepsUpward 1
+            return
+        }
+    }
+
+    end {
+    }
+}

--- a/d365fo.tools/functions/request-d365databasejitaccess.ps1
+++ b/d365fo.tools/functions/request-d365databasejitaccess.ps1
@@ -1,5 +1,4 @@
-﻿
-<#
+﻿<#
     .SYNOPSIS
         Request just in time (JIT) database access for a unified development environment (UDE)
 
@@ -18,8 +17,27 @@
     .PARAMETER ClientId
         The ClientId obtained from the Azure Portal when you created a Registered Application
 
-    .PARAMETER ClientSecret
+    .PARAMETER ClientSecretAsPlainString
         The ClientSecret obtained from the Azure Portal when you created a Registered Application
+
+        This is the plain text version of the ClientSecret parameter.
+
+        Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
+
+    .PARAMETER ClientSecretAsSecureString
+        The ClientSecret obtained from the Azure Portal when you created a Registered Application
+
+        This is the secure string version of the ClientSecret parameter.
+
+        Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
+
+    .PARAMETER Credential
+        The Credential object containing Username (ClientId) and Password (ClientSecret)
+
+        The Username will be used as ClientId
+        The Password will be used as ClientSecret
+
+        Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
 
     .PARAMETER Tenant
         Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access
@@ -27,7 +45,7 @@
     .PARAMETER ClientIPAddress
         The IP address of the client that needs database access
 
-        Default value is "127.0.0.1" for localhost access
+        Default value is "127.0.0.1" which will be replaced with the public IP address of the client as determined by querying "https://icanhazip.com"
 
     .PARAMETER Role
         The database role to assign to the JIT access
@@ -38,8 +56,6 @@
 
     .PARAMETER Reason
         The reason for requesting JIT database access
-
-        This is logged for audit purposes
 
         Default value is "Administrative access via d365fo.tools"
 
@@ -52,33 +68,56 @@
         Instructs the cmdlet to convert the output to a Json string
 
     .EXAMPLE
-        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
 
         This will request JIT database access for the D365FO environment.
-        It will use the default client IP address "127.0.0.1", role "Reader", and reason "Administrative access via d365fo.tools".
+        It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
 
     .EXAMPLE
-        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
 
         This will request JIT database access for the D365FO environment with Writer privileges.
         It will use the client IP address "192.168.1.100", role "Writer", and reason "Development work".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
 
     .EXAMPLE
-        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
 
         This will request JIT database access for the D365FO environment and display the result as json.
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-        It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+    .EXAMPLE
+        PS C:\> $clientSecretSecure = Read-Host -AsSecureString "Enter the Client Secret"
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsSecureString $clientSecretSecure
+
+        This will prompt the user to enter the client secret securely (the input will be masked).
+        Then it will request JIT database access for the D365FO environment using the secure string for authentication.
+        It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+        It will authenticate with the client secret provided through the secure prompt.
+
+    .EXAMPLE
+        PS C:\> $credential = Get-Credential -UserName "dea8d7a9-1602-4429-b138-111111111111" -Message "Enter the Client Secret"
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -Credential $credential
+
+        This will prompt the user to enter the client secret through a secure credential dialog (using the ClientId as the username).
+        Then it will request JIT database access for the D365FO environment using the credential for authentication.
+        It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the client id and secret provided through the credential object.
 
     .NOTES
         Tags: JIT, Database, Access, UDE, OData, RestApi
@@ -87,17 +126,24 @@
 
 #>
 function Request-D365DatabaseJITAccess {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ByClientSecretAsPlainString')]
     [OutputType([System.String])]
     param (
         [Parameter(Mandatory = $true)]
         [string] $Url,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByClientSecretAsPlainString')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByClientSecretAsSecureString')]
         [string] $ClientId,
 
-        [Parameter(Mandatory = $true)]
-        [string] $ClientSecret,
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByClientSecretAsPlainString')]
+        [string] $ClientSecretAsPlainString,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByClientSecretAsSecureString')]
+        [System.Security.SecureString] $ClientSecretAsSecureString,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByCredential')]
+        [System.Management.Automation.PSCredential] $Credential,
 
         [Parameter(Mandatory = $true)]
         [string] $Tenant, # TODO This could be preset from $Script.TenantId once UDE support is added (see https://github.com/d365collaborative/d365fo.tools/pull/868)
@@ -115,6 +161,18 @@ function Request-D365DatabaseJITAccess {
     )
 
     begin {
+        # Extract ClientId and ClientSecret from credential if provided
+        if ($PSCmdlet.ParameterSetName -eq 'ByCredential') {
+            $ClientId = $Credential.UserName
+            $ClientSecretAsPlainString = $Credential.GetNetworkCredential().Password
+        }
+        # Convert SecureString to plain text if ClientSecretAsSecureString is provided
+        elseif ($PSCmdlet.ParameterSetName -eq 'ByClientSecretAsSecureString') {
+            $BSTR = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($ClientSecretAsSecureString)
+            $ClientSecretAsPlainString = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($BSTR)
+        }
+
         # Clean up the URL to ensure it ends with a slash
         if (-not $Url.EndsWith('/')) {
             $Url = $Url + '/'
@@ -136,7 +194,7 @@ function Request-D365DatabaseJITAccess {
         $bearerParms = @{
             Resource        = $Url
             ClientId        = $ClientId
-            ClientSecret    = $ClientSecret
+            ClientSecret    = $ClientSecretAsPlainString
             AuthProviderUri = "https://login.microsoftonline.com/$Tenant/oauth2/token"
         }
 
@@ -196,5 +254,9 @@ function Request-D365DatabaseJITAccess {
     }
 
     end {
+        if ($PSCmdlet.ParameterSetName -ne 'ByClientSecretAsPlainString') {
+            # Clear sensitive variables
+            $ClientSecretAsPlainString = $null
+        }
     }
 }

--- a/d365fo.tools/functions/request-d365databasejitaccess.ps1
+++ b/d365fo.tools/functions/request-d365databasejitaccess.ps1
@@ -1,135 +1,136 @@
-﻿<#
+﻿
+<#
     .SYNOPSIS
         Request just in time (JIT) database access for a unified development environment (UDE)
-
+        
     .DESCRIPTION
         Utilize the D365FO Power Platform OData API to request just in time access (JIT) to a UDE database
-
+        
         This will allow you to get temporary database credentials for connecting to the database directly
-
+        
         If no credentials are provided (ClientId/ClientSecret or Credential), the function will automatically use interactive authentication via Azure PowerShell.
-
+        
     .PARAMETER Url
         URL / URI for the D365FO Power Platform environment that provides the JIT access API.
-
+        
         Note: This is not the URL of the D365FO environment itself (aka the Finance and Operations URL). Instead, it is the URL of the Power Platform environment (aka the Environment URL) that the D365FO environment is integrated with.
-
+        
         For example: "https://operations-acme-uat.crm4.dynamics.com/"
-
+        
     .PARAMETER ClientId
         The ClientId obtained from the Azure Portal when you created a Registered Application
-
+        
     .PARAMETER ClientSecretAsPlainString
         The ClientSecret obtained from the Azure Portal when you created a Registered Application
-
+        
         This is the plain text version of the ClientSecret parameter.
-
+        
         Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
-
+        
     .PARAMETER ClientSecretAsSecureString
         The ClientSecret obtained from the Azure Portal when you created a Registered Application
-
+        
         This is the secure string version of the ClientSecret parameter.
-
+        
         Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
-
+        
     .PARAMETER Credential
         The Credential object containing Username (ClientId) and Password (ClientSecret)
-
+        
         The Username will be used as ClientId
         The Password will be used as ClientSecret
-
+        
         Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
-
+        
     .PARAMETER Tenant
         Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access
-
+        
     .PARAMETER ClientIPAddress
         The IP address of the client that needs database access
-
+        
         Default value is "127.0.0.1" which will be replaced with the public IP address of the client as determined by querying "https://icanhazip.com"
-
+        
     .PARAMETER Role
         The database role to assign to the JIT access
-
+        
         Valid options are "Reader" and "Writer"
-
+        
         Default value is "Reader"
-
+        
     .PARAMETER Reason
         The reason for requesting JIT database access
-
+        
         Default value is "Administrative access via d365fo.tools"
-
+        
     .PARAMETER SQLServerManagementStudioPath
         The full path to the SQL Server Management Studio executable (ssms.exe)
-
+        
         If provided, the function will automatically open SQL Server Management Studio and connect to the database using the obtained credentials.
-
+        
         Example: "C:\Program Files\Microsoft SQL Server Management Studio 21\Release\Common7\IDE\SSMS.exe"
-
+        
         Note: Since version 18, SQL Server Management Studio does no longer allow providing the password directly in the command line. The password will be copied to clipboard instead for easy pasting. It will be cleared from clipboard after 60 seconds.
         
         Note: After SQL Server Management Studio has been started this way, it will display a "Connect to the following server?" warning dialog. Confirm it with "Yes". Next, because of the missing password, a "Connect to server" error dialog will be shown. Confirm it with "OK". Finally, a "Connect to server" form will be shown where the password can be pasted and the connection be established with the "Connect" button. Answering "No" on the first warning dialog will take you directly to the "Connect to server" form, but the database information will not be pre-filled.
-
+        
         Note: The connection may fail at first because it takes some time until the client's IP address is whitelisted in the Azure SQL Database firewall rules. If that happens, just try again after a minute or so.
-
+        
     .PARAMETER RawOutput
         Instructs the cmdlet to include the outer structure of the response received from the endpoint
-
+        
         The output will still be a PSCustomObject
-
+        
     .PARAMETER OutputAsJson
         Instructs the cmdlet to convert the output to a Json string
-
+        
     .PARAMETER EnableException
         This parameters disables user-friendly warnings and enables the throwing of exceptions
         This is less user friendly, but allows catching exceptions in calling scripts
         Usually this parameter is not used directly, but via the Enable-D365Exception cmdlet
         See https://github.com/d365collaborative/d365fo.tools/wiki/Exception-handling#what-does-the--enableexception-parameter-do for further information
-
+        
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111"
-
+        
         This will request JIT database access for the D365FO environment using interactive authentication.
         It will prompt you to sign in with your Azure AD credentials if not already signed in.
         It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
-    
+        
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
-
+        
         This will request JIT database access for the D365FO environment.
         It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-
+        
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
-
+        
         This will request JIT database access for the D365FO environment with Writer privileges.
         It will use the client IP address "192.168.1.100", role "Writer", and reason "Development work".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-
+        
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
-
+        
         This will request JIT database access for the D365FO environment and display the result as json.
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-
+        
     .EXAMPLE
         PS C:\> $clientSecretSecure = Read-Host -AsSecureString "Enter the Client Secret"
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsSecureString $clientSecretSecure
-
+        
         This will prompt the user to enter the client secret securely (the input will be masked).
         Then it will request JIT database access for the D365FO environment using the secure string for authentication.
         It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
@@ -137,32 +138,32 @@
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the client secret provided through the secure prompt.
-
+        
     .EXAMPLE
         PS C:\> $credential = Get-Credential -UserName "dea8d7a9-1602-4429-b138-111111111111" -Message "Enter the Client Secret"
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -Credential $credential
-
+        
         This will prompt the user to enter the client secret through a secure credential dialog (using the ClientId as the username).
         Then it will request JIT database access for the D365FO environment using the credential for authentication.
         It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the client id and secret provided through the credential object.
-
+        
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -SQLServerManagementStudioPath "C:\Program Files\Microsoft SQL Server Management Studio 21\Release\Common7\IDE\SSMS.exe"
-
+        
         This will request JIT database access for the D365FO environment using interactive authentication.
         It will open SQL Server Management Studio and connect to the database using the obtained credentials.
         It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
-
+        
     .NOTES
         Tags: JIT, Database, Access, UDE, OData, RestApi
-
+        
         Author: Florian Hopfner (@FH-Inway)
-
+        
 #>
 function Request-D365DatabaseJITAccess {
     [CmdletBinding(DefaultParameterSetName = 'ByInteractiveLogin')]

--- a/d365fo.tools/functions/request-d365databasejitaccess.ps1
+++ b/d365fo.tools/functions/request-d365databasejitaccess.ps1
@@ -2,91 +2,91 @@
 <#
     .SYNOPSIS
         Request just in time (JIT) database access for a unified development environment (UDE)
-        
+
     .DESCRIPTION
         Utilize the D365FO OData API to request just in time access (JIT) to a UDE database
-        
+
         This will allow you to get temporary database credentials for connecting to the database directly
-        
+
     .PARAMETER Url
         URL / URI for the D365FO environment you want to access
-        
+
         If you are working against a D365FO instance, it will be the URL / URI for the instance itself
-        
+
         This should be the full URL, e.g. "https://operations-acme-uat.crm4.dynamics.com/"
-        
+
     .PARAMETER ClientId
         The ClientId obtained from the Azure Portal when you created a Registered Application
-        
+
     .PARAMETER ClientSecret
         The ClientSecret obtained from the Azure Portal when you created a Registered Application
-        
+
     .PARAMETER Tenant
         Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access
-        
+
     .PARAMETER ClientIPAddress
         The IP address of the client that needs database access
-        
+
         Default value is "127.0.0.1" for localhost access
-        
+
     .PARAMETER Role
         The database role to assign to the JIT access
-        
+
         Valid options are "Reader" and "Writer"
-        
+
         Default value is "Reader"
-        
+
     .PARAMETER Reason
         The reason for requesting JIT database access
-        
+
         This is logged for audit purposes
-        
+
         Default value is "Administrative access via d365fo.tools"
-        
+
     .PARAMETER RawOutput
         Instructs the cmdlet to include the outer structure of the response received from the endpoint
-        
+
         The output will still be a PSCustomObject
-        
+
     .PARAMETER OutputAsJson
         Instructs the cmdlet to convert the output to a Json string
-        
+
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
-        
+
         This will request JIT database access for the D365FO environment.
         It will use the default client IP address "127.0.0.1", role "Reader", and reason "Administrative access via d365fo.tools".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-        
+
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
-        
+
         This will request JIT database access for the D365FO environment with Writer privileges.
         It will use the client IP address "192.168.1.100", role "Writer", and reason "Development work".
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-        
+
     .EXAMPLE
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
-        
+
         This will request JIT database access for the D365FO environment and display the result as json.
         It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
         It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
         It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
         It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
-        
+
     .NOTES
         Tags: JIT, Database, Access, UDE, OData, RestApi
-        
+
         Author: Mötz Jensen (@Splaxi)
-        
+
         This cmdlet is inspired by the PowerShell script provided in GitHub issue for d365fo.tools
-        
+
 #>
 function Request-D365DatabaseJITAccess {
     [CmdletBinding()]

--- a/d365fo.tools/functions/request-d365databasejitaccess.ps1
+++ b/d365fo.tools/functions/request-d365databasejitaccess.ps1
@@ -128,6 +128,15 @@
         It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
         
     .EXAMPLE
+        PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -RawOutput
+        
+        This will request JIT database access for the D365FO environment and display the result as object with the content as it was received from the endpoint.
+        It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+        It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+        It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+        It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+        
+    .EXAMPLE
         PS C:\> $clientSecretSecure = Read-Host -AsSecureString "Enter the Client Secret"
         PS C:\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsSecureString $clientSecretSecure
         
@@ -166,6 +175,9 @@
         
 #>
 function Request-D365DatabaseJITAccess {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingConvertToSecureStringWithPlainText', '',
+        Justification = 'Converting plain text to Secure.String provides protection against accidental exposure in logs etc. when used correctly. Encrypting the plain text first would make it too difficult to use.')]
     [CmdletBinding(DefaultParameterSetName = 'ByInteractiveLogin')]
     [OutputType([System.String])]
     param (
@@ -245,7 +257,7 @@ function Request-D365DatabaseJITAccess {
             }
             
             $bearer = Invoke-ClientCredentialsGrant @bearerParms | Get-BearerToken
-        } 
+        }
         else {
             try {
                 # Check if already connected
@@ -321,7 +333,7 @@ function Request-D365DatabaseJITAccess {
                 # Extract the relevant information from the response
                 $selectParams = @{
                     TypeName = "D365FO.TOOLS.UDE.JITDatabaseAccess"
-                    Property = @{Name = "SQLJITCredential"; Expression = { 
+                    Property = @{Name = "SQLJITCredential"; Expression = {
                         $password = $_.sqljitpassword | ConvertTo-SecureString -AsPlainText -Force
                         New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ($_.sqljitusername, $password)
                         }},

--- a/d365fo.tools/tests/functions/Request-D365DatabaseJITAccess.Tests.ps1
+++ b/d365fo.tools/tests/functions/Request-D365DatabaseJITAccess.Tests.ps1
@@ -1,0 +1,139 @@
+﻿Describe "Request-D365DatabaseJITAccess Unit Tests" -Tag "Unit" {
+	BeforeAll {
+		# Place here all things needed to prepare for the tests
+	}
+	AfterAll {
+		# Here is where all the cleanup tasks go
+	}
+	
+	Describe "Ensuring unchanged command signature" {
+		It "should have the expected parameter sets" {
+			(Get-Command Request-D365DatabaseJITAccess).ParameterSets.Name | Should -Be '__AllParameterSets'
+		}
+		
+		It 'Should have the expected parameter Url' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Url']
+			$parameter.Name | Should -Be 'Url'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ClientId' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientId']
+			$parameter.Name | Should -Be 'ClientId'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 1
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ClientSecret' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientSecret']
+			$parameter.Name | Should -Be 'ClientSecret'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 2
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter Tenant' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Tenant']
+			$parameter.Name | Should -Be 'Tenant'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 3
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ClientIPAddress' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientIPAddress']
+			$parameter.Name | Should -Be 'ClientIPAddress'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 4
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter Role' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Role']
+			$parameter.Name | Should -Be 'Role'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 5
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter Reason' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Reason']
+			$parameter.Name | Should -Be 'Reason'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 6
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter RawOutput' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['RawOutput']
+			$parameter.Name | Should -Be 'RawOutput'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter OutputAsJson' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['OutputAsJson']
+			$parameter.Name | Should -Be 'OutputAsJson'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+	}
+	
+	Describe "Ensuring ValidateSet works on Role parameter" {
+		It "should only allow 'Reader' and 'Writer' for Role parameter" {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Role']
+			$parameter.Attributes.ValidValues | Should -Be @('Reader', 'Writer')
+		}
+	}
+}

--- a/d365fo.tools/tests/functions/Request-D365DatabaseJITAccess.Tests.ps1
+++ b/d365fo.tools/tests/functions/Request-D365DatabaseJITAccess.Tests.ps1
@@ -8,7 +8,7 @@
 	
 	Describe "Ensuring unchanged command signature" {
 		It "should have the expected parameter sets" {
-			(Get-Command Request-D365DatabaseJITAccess).ParameterSets.Name | Should -Be '__AllParameterSets'
+			(Get-Command Request-D365DatabaseJITAccess).ParameterSets.Name | Should -Be 'ByInteractiveLogin', 'ByClientSecretAsSecureString', 'ByClientSecretAsPlainString', 'ByCredential'
 		}
 		
 		It 'Should have the expected parameter Url' {
@@ -19,7 +19,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -29,26 +29,58 @@
 			$parameter.Name | Should -Be 'ClientId'
 			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
-			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 1
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ByClientSecretAsSecureString', 'ByClientSecretAsPlainString'
+			$parameter.ParameterSets.Keys | Should -Contain 'ByClientSecretAsSecureString'
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Contain 'ByClientSecretAsPlainString'
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromRemainingArguments | Should -Be $False
 		}
-		It 'Should have the expected parameter ClientSecret' {
-			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientSecret']
-			$parameter.Name | Should -Be 'ClientSecret'
+		It 'Should have the expected parameter ClientSecretAsPlainString' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientSecretAsPlainString']
+			$parameter.Name | Should -Be 'ClientSecretAsPlainString'
 			$parameter.ParameterType.ToString() | Should -Be System.String
 			$parameter.IsDynamic | Should -Be $False
-			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
-			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
-			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 2
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ByClientSecretAsPlainString'
+			$parameter.ParameterSets.Keys | Should -Contain 'ByClientSecretAsPlainString'
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsPlainString'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ClientSecretAsSecureString' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['ClientSecretAsSecureString']
+			$parameter.Name | Should -Be 'ClientSecretAsSecureString'
+			$parameter.ParameterType.ToString() | Should -Be System.Security.SecureString
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ByClientSecretAsSecureString'
+			$parameter.ParameterSets.Keys | Should -Contain 'ByClientSecretAsSecureString'
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ByClientSecretAsSecureString'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter Credential' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Credential']
+			$parameter.Name | Should -Be 'Credential'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.PSCredential
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be 'ByCredential'
+			$parameter.ParameterSets.Keys | Should -Contain 'ByCredential'
+			$parameter.ParameterSets['ByCredential'].IsMandatory | Should -Be $True
+			$parameter.ParameterSets['ByCredential'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['ByCredential'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['ByCredential'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['ByCredential'].ValueFromRemainingArguments | Should -Be $False
 		}
 		It 'Should have the expected parameter Tenant' {
 			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Tenant']
@@ -58,7 +90,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $True
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 3
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -71,7 +103,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 4
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -84,7 +116,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 5
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -97,7 +129,20 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 6
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter SQLServerManagementStudioPath' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['SQLServerManagementStudioPath']
+			$parameter.Name | Should -Be 'SQLServerManagementStudioPath'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -128,12 +173,44 @@
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
-	}
-	
-	Describe "Ensuring ValidateSet works on Role parameter" {
-		It "should only allow 'Reader' and 'Writer' for Role parameter" {
-			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['Role']
-			$parameter.Attributes.ValidValues | Should -Be @('Reader', 'Writer')
+		It 'Should have the expected parameter EnableException' {
+			$parameter = (Get-Command Request-D365DatabaseJITAccess).Parameters['EnableException']
+			$parameter.Name | Should -Be 'EnableException'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
 	}
+	
+	Describe "Testing parameterset ByInteractiveLogin" {
+		<#
+		ByInteractiveLogin -Url -Tenant
+		ByInteractiveLogin -Url -Tenant -ClientIPAddress -Role -Reason -SQLServerManagementStudioPath -RawOutput -OutputAsJson -EnableException
+		#>
+	}
+ 	Describe "Testing parameterset ByClientSecretAsSecureString" {
+		<#
+		ByClientSecretAsSecureString -Url -ClientId -ClientSecretAsSecureString -Tenant
+		ByClientSecretAsSecureString -Url -ClientId -ClientSecretAsSecureString -Tenant -ClientIPAddress -Role -Reason -SQLServerManagementStudioPath -RawOutput -OutputAsJson -EnableException
+		#>
+	}
+ 	Describe "Testing parameterset ByClientSecretAsPlainString" {
+		<#
+		ByClientSecretAsPlainString -Url -ClientId -ClientSecretAsPlainString -Tenant
+		ByClientSecretAsPlainString -Url -ClientId -ClientSecretAsPlainString -Tenant -ClientIPAddress -Role -Reason -SQLServerManagementStudioPath -RawOutput -OutputAsJson -EnableException
+		#>
+	}
+ 	Describe "Testing parameterset ByCredential" {
+		<#
+		ByCredential -Url -Credential -Tenant
+		ByCredential -Url -Credential -Tenant -ClientIPAddress -Role -Reason -SQLServerManagementStudioPath -RawOutput -OutputAsJson -EnableException
+		#>
+	}
+
 }

--- a/docs/Request-D365DatabaseJITAccess.md
+++ b/docs/Request-D365DatabaseJITAccess.md
@@ -1,4 +1,4 @@
----
+﻿---
 external help file: d365fo.tools-help.xml
 Module Name: d365fo.tools
 online version:
@@ -12,34 +12,69 @@ Request just in time (JIT) database access for a unified development environment
 
 ## SYNTAX
 
+### ByInteractiveLogin (Default)
 ```
-Request-D365DatabaseJITAccess [-Url] <String> [-ClientId] <String> [-ClientSecret] <String>
- [-Tenant] <String> [[-ClientIPAddress] <String>] [[-Role] <String>] [[-Reason] <String>] [-RawOutput]
- [-OutputAsJson] [<CommonParameters>]
+Request-D365DatabaseJITAccess -Url <String> -Tenant <String> [-ClientIPAddress <String>] [-Role <String>]
+ [-Reason <String>] [-SQLServerManagementStudioPath <String>] [-RawOutput] [-OutputAsJson] [-EnableException]
+ [<CommonParameters>]
+```
+
+### ByClientSecretAsSecureString
+```
+Request-D365DatabaseJITAccess -Url <String> -ClientId <String> -ClientSecretAsSecureString <SecureString>
+ -Tenant <String> [-ClientIPAddress <String>] [-Role <String>] [-Reason <String>]
+ [-SQLServerManagementStudioPath <String>] [-RawOutput] [-OutputAsJson] [-EnableException] [<CommonParameters>]
+```
+
+### ByClientSecretAsPlainString
+```
+Request-D365DatabaseJITAccess -Url <String> -ClientId <String> -ClientSecretAsPlainString <String>
+ -Tenant <String> [-ClientIPAddress <String>] [-Role <String>] [-Reason <String>]
+ [-SQLServerManagementStudioPath <String>] [-RawOutput] [-OutputAsJson] [-EnableException] [<CommonParameters>]
+```
+
+### ByCredential
+```
+Request-D365DatabaseJITAccess -Url <String> -Credential <PSCredential> -Tenant <String>
+ [-ClientIPAddress <String>] [-Role <String>] [-Reason <String>] [-SQLServerManagementStudioPath <String>]
+ [-RawOutput] [-OutputAsJson] [-EnableException] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Utilize the D365FO OData API to request just in time access (JIT) to a UDE database
+Utilize the D365FO Power Platform OData API to request just in time access (JIT) to a UDE database
 
 This will allow you to get temporary database credentials for connecting to the database directly
+
+If no credentials are provided (ClientId/ClientSecret or Credential), the function will automatically use interactive authentication via Azure PowerShell.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111"
 ```
 
-This will request JIT database access for the D365FO environment.
-It will use the default client IP address "127.0.0.1", role "Reader", and reason "Administrative access via d365fo.tools".
+This will request JIT database access for the D365FO environment using interactive authentication.
+It will prompt you to sign in with your Azure AD credentials if not already signed in.
+It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
 It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
-It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
-It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
 
 ### EXAMPLE 2
 ```
-Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
+```
+
+This will request JIT database access for the D365FO environment.
+It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+### EXAMPLE 3
+```
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
 ```
 
 This will request JIT database access for the D365FO environment with Writer privileges.
@@ -47,27 +82,68 @@ It will use the client IP address "192.168.1.100", role "Writer", and reason "De
 It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
 It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
 It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
 
-### EXAMPLE 3
+### EXAMPLE 4
 ```
-Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsPlainString "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
 ```
 
 This will request JIT database access for the D365FO environment and display the result as json.
 It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
 It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
 It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
-It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+It will authenticate with the specified ClientSecretAsPlainString parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+### EXAMPLE 5
+```
+$clientSecretSecure = Read-Host -AsSecureString "Enter the Client Secret"
+```
+
+PS C:\\\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecretAsSecureString $clientSecretSecure
+
+This will prompt the user to enter the client secret securely (the input will be masked).
+Then it will request JIT database access for the D365FO environment using the secure string for authentication.
+It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+It will authenticate with the client secret provided through the secure prompt.
+
+### EXAMPLE 6
+```
+$credential = Get-Credential -UserName "dea8d7a9-1602-4429-b138-111111111111" -Message "Enter the Client Secret"
+```
+
+PS C:\\\> Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -Credential $credential
+
+This will prompt the user to enter the client secret through a secure credential dialog (using the ClientId as the username).
+Then it will request JIT database access for the D365FO environment using the credential for authentication.
+It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the client id and secret provided through the credential object.
+
+### EXAMPLE 7
+```
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -SQLServerManagementStudioPath "C:\Program Files\Microsoft SQL Server Management Studio 21\Release\Common7\IDE\SSMS.exe"
+```
+
+This will request JIT database access for the D365FO environment using interactive authentication.
+It will open SQL Server Management Studio and connect to the database using the obtained credentials.
+It will use the client's IP address, role "Reader", and reason "Administrative access via d365fo.tools".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
 
 ## PARAMETERS
 
 ### -Url
-URL / URI for the D365FO environment you want to access
+URL / URI for the D365FO Power Platform environment that provides the JIT access API.
 
-If you are working against a D365FO instance, it will be the URL / URI for the instance itself
+Note: This is not the URL of the D365FO environment itself (aka the Finance and Operations URL).
+Instead, it is the URL of the Power Platform environment (aka the Environment URL) that the D365FO environment is integrated with.
 
-This should be the full URL, e.g. "https://operations-acme-uat.crm4.dynamics.com/"
+For example: "https://operations-acme-uat.crm4.dynamics.com/"
 
 ```yaml
 Type: String
@@ -75,7 +151,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -86,26 +162,69 @@ The ClientId obtained from the Azure Portal when you created a Registered Applic
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ByClientSecretAsSecureString, ByClientSecretAsPlainString
 Aliases:
 
 Required: True
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ClientSecret
+### -ClientSecretAsPlainString
 The ClientSecret obtained from the Azure Portal when you created a Registered Application
+
+This is the plain text version of the ClientSecret parameter.
+
+Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ByClientSecretAsPlainString
 Aliases:
 
 Required: True
-Position: 2
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientSecretAsSecureString
+The ClientSecret obtained from the Azure Portal when you created a Registered Application
+
+This is the secure string version of the ClientSecret parameter.
+
+Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
+
+```yaml
+Type: SecureString
+Parameter Sets: ByClientSecretAsSecureString
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+The Credential object containing Username (ClientId) and Password (ClientSecret)
+
+The Username will be used as ClientId
+The Password will be used as ClientSecret
+
+Either ClientSecretAsPlainString, ClientSecretAsSecureString, or Credential must be provided.
+
+```yaml
+Type: PSCredential
+Parameter Sets: ByCredential
+Aliases:
+
+Required: True
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -120,7 +239,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 3
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -129,7 +248,7 @@ Accept wildcard characters: False
 ### -ClientIPAddress
 The IP address of the client that needs database access
 
-Default value is "127.0.0.1" for localhost access
+Default value is "127.0.0.1" which will be replaced with the public IP address of the client as determined by querying "https://icanhazip.com"
 
 ```yaml
 Type: String
@@ -137,7 +256,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 4
+Position: Named
 Default value: 127.0.0.1
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -156,7 +275,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 5
+Position: Named
 Default value: Reader
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -164,8 +283,6 @@ Accept wildcard characters: False
 
 ### -Reason
 The reason for requesting JIT database access
-
-This is logged for audit purposes
 
 Default value is "Administrative access via d365fo.tools"
 
@@ -175,8 +292,41 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 6
+Position: Named
 Default value: Administrative access via d365fo.tools
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SQLServerManagementStudioPath
+The full path to the SQL Server Management Studio executable (ssms.exe)
+
+If provided, the function will automatically open SQL Server Management Studio and connect to the database using the obtained credentials.
+
+Example: "C:\Program Files\Microsoft SQL Server Management Studio 21\Release\Common7\IDE\SSMS.exe"
+
+Note: Since version 18, SQL Server Management Studio does no longer allow providing the password directly in the command line.
+The password will be copied to clipboard instead for easy pasting.
+It will be cleared from clipboard after 60 seconds.
+
+Note: After SQL Server Management Studio has been started this way, it will display a "Connect to the following server?" warning dialog.
+Confirm it with "Yes".
+Next, because of the missing password, a "Connect to server" error dialog will be shown.
+Confirm it with "OK".
+Finally, a "Connect to server" form will be shown where the password can be pasted and the connection be established with the "Connect" button.
+Answering "No" on the first warning dialog will take you directly to the "Connect to server" form, but the database information will not be pre-filled.
+
+Note: The connection may fail at first because it takes some time until the client's IP address is whitelisted in the Azure SQL Database firewall rules.
+If that happens, just try again after a minute or so.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -213,6 +363,24 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -EnableException
+This parameters disables user-friendly warnings and enables the throwing of exceptions
+This is less user friendly, but allows catching exceptions in calling scripts
+Usually this parameter is not used directly, but via the Enable-D365Exception cmdlet
+See https://github.com/d365collaborative/d365fo.tools/wiki/Exception-handling#what-does-the--enableexception-parameter-do for further information
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
@@ -220,11 +388,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.String
 ## NOTES
 Tags: JIT, Database, Access, UDE, OData, RestApi
 
-Author: Mötz Jensen (@Splaxi)
-
-This cmdlet is inspired by the PowerShell script provided in GitHub issue for d365fo.tools
+Author: Florian Hopfner (@FH-Inway)
 
 ## RELATED LINKS

--- a/docs/Request-D365DatabaseJITAccess.md
+++ b/docs/Request-D365DatabaseJITAccess.md
@@ -1,0 +1,230 @@
+---
+external help file: d365fo.tools-help.xml
+Module Name: d365fo.tools
+online version:
+schema: 2.0.0
+---
+
+# Request-D365DatabaseJITAccess
+
+## SYNOPSIS
+Request just in time (JIT) database access for a unified development environment (UDE)
+
+## SYNTAX
+
+```
+Request-D365DatabaseJITAccess [-Url] <String> [-ClientId] <String> [-ClientSecret] <String>
+ [-Tenant] <String> [[-ClientIPAddress] <String>] [[-Role] <String>] [[-Reason] <String>] [-RawOutput]
+ [-OutputAsJson] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Utilize the D365FO OData API to request just in time access (JIT) to a UDE database
+
+This will allow you to get temporary database credentials for connecting to the database directly
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522"
+```
+
+This will request JIT database access for the D365FO environment.
+It will use the default client IP address "127.0.0.1", role "Reader", and reason "Administrative access via d365fo.tools".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the "https://login.microsoftonline.com/e674da86-7ee5-40a7-b777-1111111111111/oauth2/token" url with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+### EXAMPLE 2
+```
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -ClientIPAddress "192.168.1.100" -Role "Writer" -Reason "Development work"
+```
+
+This will request JIT database access for the D365FO environment with Writer privileges.
+It will use the client IP address "192.168.1.100", role "Writer", and reason "Development work".
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+### EXAMPLE 3
+```
+Request-D365DatabaseJITAccess -Url "https://operations-acme-uat.crm4.dynamics.com/" -Tenant "e674da86-7ee5-40a7-b777-1111111111111" -ClientId "dea8d7a9-1602-4429-b138-111111111111" -ClientSecret "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522" -OutputAsJson
+```
+
+This will request JIT database access for the D365FO environment and display the result as json.
+It will contact the D365FO instance specified in the Url parameter: "https://operations-acme-uat.crm4.dynamics.com/".
+It will authenticate against the Azure Active Directory with the specified Tenant parameter: "e674da86-7ee5-40a7-b777-1111111111111".
+It will authenticate with the specified ClientId parameter: "dea8d7a9-1602-4429-b138-111111111111".
+It will authenticate with the specified ClientSecret parameter: "Vja/VmdxaLOPR+alkjfsadffelkjlfw234522".
+
+## PARAMETERS
+
+### -Url
+URL / URI for the D365FO environment you want to access
+
+If you are working against a D365FO instance, it will be the URL / URI for the instance itself
+
+This should be the full URL, e.g. "https://operations-acme-uat.crm4.dynamics.com/"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientId
+The ClientId obtained from the Azure Portal when you created a Registered Application
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientSecret
+The ClientSecret obtained from the Azure Portal when you created a Registered Application
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tenant
+Azure Active Directory (AAD) tenant id (Guid) that the D365FO environment is connected to, that you want to access
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientIPAddress
+The IP address of the client that needs database access
+
+Default value is "127.0.0.1" for localhost access
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: 127.0.0.1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Role
+The database role to assign to the JIT access
+
+Valid options are "Reader" and "Writer"
+
+Default value is "Reader"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: Reader
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Reason
+The reason for requesting JIT database access
+
+This is logged for audit purposes
+
+Default value is "Administrative access via d365fo.tools"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: Administrative access via d365fo.tools
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RawOutput
+Instructs the cmdlet to include the outer structure of the response received from the endpoint
+
+The output will still be a PSCustomObject
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputAsJson
+Instructs the cmdlet to convert the output to a Json string
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Tags: JIT, Database, Access, UDE, OData, RestApi
+
+Author: Mötz Jensen (@Splaxi)
+
+This cmdlet is inspired by the PowerShell script provided in GitHub issue for d365fo.tools
+
+## RELATED LINKS


### PR DESCRIPTION
This pull request adds the new PowerShell cmdlet `Request-D365DatabaseJITAccess` for requesting just-in-time (JIT) database access for D365 Finance and Operations unified development environments (UDE). The cmdlet allows users to obtain temporary credentials for direct database access, supporting multiple authentication methods and integration with SQL Server Management Studio. The changes also register the new cmdlet in the module manifest.

Resolves #897 

## New experience

``` pwsh
$params = @{
    Url = "https://my-unified-dev.crm4.dynamics.com/"
    Tenant = "e674da86-7ee5-40a7-b777-1111111111111"
    RawOutput = $true
}
Request-D365DatabaseJITAccess @params
```

<img width="1402" height="788" alt="image" src="https://github.com/user-attachments/assets/57a907a6-26b7-4d95-8059-480f225058dc" />

## Open SSMS

This is the simplest way to use the new command, but not necessarily the best. One quality of life parameter is `-SQLServerManagementStudioPath`, which lets you specify the path to the SQL Server Management Studio ssms.exe (usually the path looks similar to `C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\ssms.exe`). This lets the command open SSMS with the connection information. Unfortunately, the password cannot be provided in newer SSMS versions. So instead, it is copied to the clipboard so the user can paste it in the connection form.

Unfortunately, getting to the connection form without the password is a bit tricky. First, you get a warning dialog asking if it should connect.
<img width="772" height="271" alt="image" src="https://github.com/user-attachments/assets/bd72b9bb-622a-457b-9ffc-3345922a29c7" />
Since the password is missing at that point, this fails with an error dialog.
<img width="771" height="222" alt="image" src="https://github.com/user-attachments/assets/aecfa18a-0505-434a-b6e4-222858933c3b" />
After that, you get to the connection form where the password can be pasted and the connection be established. 
<img width="608" height="445" alt="image" src="https://github.com/user-attachments/assets/afe363ef-dfda-45e7-88b9-d46efd32af40" />
May take a few tries until the firewall accepts the IP address (the command will automatically determine the IP address, but can also be provided with the `-ClientIPAddress` parameter).

## Export bacpac

The access information can also be used to export the database .bacpac file like so:
``` pwsh
$params = @{
    Url = "https://my-unified-dev.crm4.dynamics.com/"
    Tenant = "e674da86-7ee5-40a7-b777-1111111111111"
    # Note no -RawOutput parameter is provided here. This causes the SQL JIT user name and password to be wrapped in a PSCredential property of the returned object, which provides additional security for the password.
}
$dbaccess = Request-D365DatabaseJITAccess @params

$bacpacParams = @{
    ExportModeTier2 = $true # Only with ExportModeTier2 can a SqlUser and SqlPwd be provided. We should add a switch ExportModeUDE with the same behavior to make it clearer that this can be used for UDE as well.
    ExportOnly = $true # Haven't tested the additional stuff around the bacpac export, it very likely will need some changes to work with UDE
    DatabaseServer = $dbaccess.ServerName
    DatabaseName = $dbaccess.DatabaseName
    SqlUser = $dbaccess.SQLJITCredential.UserName
    SqlPwd = $dbaccess.SQLJITCredential.GetNetworkCredential().Password # To connect to the database, the password is required again in plain text
    BacpacFile = "C:\Temp\weber-unified-dev.bacpac"
    Verbose = $true
}
New-D365Bacpac @bacpacParams
```

