### PR TITLE
Update QueryStoreCaptureMode value in JSON

### DIFF
--- a/d365fo.tools/internal/misc/RepairBacpac.Replace.json
+++ b/d365fo.tools/internal/misc/RepairBacpac.Replace.json
@@ -2,5 +2,9 @@
     {
         "Search": "<Property Name=\"AutoDrop\" Value=\"True\" />",
         "Replace": ""
+    },
+    {
+        "Search": "<Property Name=\"QueryStoreCaptureMode\" Value=\"4\" />",
+        "Replace": "<Property Name=\"QueryStoreCaptureMode\" Value=\"2\" />"
     }
 ]


### PR DESCRIPTION
This old issue appeared for me when importing bacpac exported from UDE environment. The option 4 for querystore query_capture_mode is not supported. Details in this discussion: https://community.dynamics.com/forums/thread/details/?threadid=0e2e7d36-3b6c-4b65-99e4-c29a71e3ec76