### PR TITLE
feat: Add -UpdateObjectId and -ObjectId params to Import-D365External…

### DIFF
--- a/d365fo.tools/bin/d365fo.tools-index.json
+++ b/d365fo.tools/bin/d365fo.tools-index.json
@@ -5898,6 +5898,22 @@
                            "en-us"
                        ],
                        [
+                           "UpdateObjectId",
+                           "Switch to look up the user\u0027s Azure AD ObjectId from Microsoft Graph and store it in D365FO.\nWhen this switch is enabled, the cmdlet calls Microsoft Graph\r\n(https://graph.microsoft.com/v1.0/users) to resolve the ObjectId for the given Email address\r\nand passes it to the underlying SQL import. This fixes a known issue where restoring a\r\nTier-2 database to a Tier-1 environment causes user sign-in failures because the UserInfo\r\ntable\u0027s OBJECTID column is incorrectly copied from the admin user.\nRequires an active Azure connection (Connect-AzAccount) before calling this cmdlet.\nWithout this switch, ObjectId is left empty and existing behavior is preserved.",
+                           "",
+                           false,
+                           "false",
+                           "False"
+                       ],
+                       [
+                           "ObjectId",
+                           "Explicitly provide the Azure AD ObjectId for the user being imported.\nUse this when you already know the ObjectId and want to avoid the Graph API call.\r\nIf both -UpdateObjectId and -ObjectId are specified, the explicitly provided -ObjectId\r\nvalue takes precedence and no Graph lookup is performed.",
+                           "",
+                           false,
+                           "false",
+                           ""
+                       ],
+                       [
                            "DatabaseServer",
                            "The name of the database server\nIf on-premises or classic SQL Server, use either short name og Fully Qualified Domain Name (FQDN)\nIf Azure use the full address to the database server, e.g. server.database.windows.net",
                            "",
@@ -5935,8 +5951,8 @@
         "Synopsis":  "Import an user from an external Azure Active Directory (AAD)",
         "Name":  "Import-D365ExternalUser",
         "Links":  null,
-        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eImport-D365ExternalUser -Id \"John\" -Name \"John Doe\" -Email \"John@contoso.com\"\nThis will import an user from an external Azure Active Directory.\r\nThe new user will get the system wide Id \"John\".\r\nThe name of the new user will be \"John Doe\".\r\nThe e-mail address / sign-in e-mail address will be registered as \"John@contoso.com\".",
-        "Syntax":  "Import-D365ExternalUser [-Id] \u003cString\u003e [-Name] \u003cString\u003e [-Email] \u003cString\u003e [[-Enabled] \u003cInt32\u003e] [[-Company] \u003cString\u003e] [[-Language] \u003cString\u003e] [[-DatabaseServer] \u003cString\u003e] [[-DatabaseName] \u003cString\u003e] [[-SqlUser] \u003cString\u003e] [[-SqlPwd] \u003cString\u003e] [\u003cCommonParameters\u003e]"
+        "Examples":  "-------------------------- EXAMPLE 1 --------------------------\nPS C:\\\u003eImport-D365ExternalUser -Id \"John\" -Name \"John Doe\" -Email \"John@contoso.com\"\nThis will import an user from an external Azure Active Directory.\r\nThe new user will get the system wide Id \"John\".\r\nThe name of the new user will be \"John Doe\".\r\nThe e-mail address / sign-in e-mail address will be registered as \"John@contoso.com\".\n-------------------------- EXAMPLE 2 --------------------------\nPS C:\\\u003eConnect-AzAccount\nPS C:\\\u003e Import-D365ExternalUser -Id \"John\" -Name \"John Doe\" -Email \"John@contoso.com\" -UpdateObjectId\nThis will import an user from an external Azure Active Directory and resolve the user\u0027s\r\nObjectId from Microsoft Graph to store in D365FO.\nConnect-AzAccount is required before using -UpdateObjectId.\nResolving the ObjectId is necessary to avoid login failures in environments that have had\r\ntheir database restored from a Tier-2 environment, where the UserInfo OBJECTID column would\r\notherwise be copied from the environment\u0027s admin user.\n-------------------------- EXAMPLE 3 --------------------------\nPS C:\\\u003eImport-D365ExternalUser -Id \"John\" -Name \"John Doe\" -Email \"John@contoso.com\" -ObjectId \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"\nThis will import an user from an external Azure Active Directory and use the supplied\r\nObjectId directly, without making a Microsoft Graph API call.",
+        "Syntax":  "Import-D365ExternalUser [-Id] \u003cString\u003e [-Name] \u003cString\u003e [-Email] \u003cString\u003e [[-Enabled] \u003cInt32\u003e] [[-Company] \u003cString\u003e] [[-Language] \u003cString\u003e] [-UpdateObjectId] [[-ObjectId] \u003cString\u003e] [[-DatabaseServer] \u003cString\u003e] [[-DatabaseName] \u003cString\u003e] [[-SqlUser] \u003cString\u003e] [[-SqlPwd] \u003cString\u003e] [\u003cCommonParameters\u003e]"
     },
     {
         "CommandName":  "Import-D365Model",

--- a/d365fo.tools/functions/import-d365externaluser.ps1
+++ b/d365fo.tools/functions/import-d365externaluser.ps1
@@ -1,70 +1,109 @@
-﻿
+
 <#
     .SYNOPSIS
         Import an user from an external Azure Active Directory (AAD)
-        
+
     .DESCRIPTION
         Imports an user from an AAD that is NOT the same as the AAD tenant that the D365FO environment is running under
-        
+
     .PARAMETER Id
         The internal Id that the user must be imported with
-        
+
         The Id has to unique across the entire user base
-        
+
     .PARAMETER Name
         The display name of the user inside the D365FO environment
-        
+
     .PARAMETER Email
         The email address of the user that you want to import
-        
+
         This is also the sign-in user name / e-mail address to gain access to the system
-        
+
         If the external AAD tenant has multiple custom domain names, you have to use the domain that they have configured as default
-        
+
     .PARAMETER Company
         Default company that should be configured for the user, for when they sign-in to the D365 environment
-        
+
         Default value is "DAT"
-        
+
     .PARAMETER Language
         Language that should be configured for the user, for when they sign-in to the D365 environment
-        
+
         Default value is "en-US"
-        
+
     .PARAMETER Enabled
         Should the imported user be enabled or not?
-        
+
         Default value is 1, which equals true / yes
-        
+
+    .PARAMETER UpdateObjectId
+        Switch to look up the user's Azure AD ObjectId from Microsoft Graph and store it in D365FO.
+
+        When this switch is enabled, the cmdlet calls Microsoft Graph
+        (https://graph.microsoft.com/v1.0/users) to resolve the ObjectId for the given Email address
+        and passes it to the underlying SQL import. This fixes a known issue where restoring a
+        Tier-2 database to a Tier-1 environment causes user sign-in failures because the UserInfo
+        table's OBJECTID column is incorrectly copied from the admin user.
+
+        Requires an active Azure connection (Connect-AzAccount) before calling this cmdlet.
+
+        Without this switch, ObjectId is left empty and existing behavior is preserved.
+
+    .PARAMETER ObjectId
+        Explicitly provide the Azure AD ObjectId for the user being imported.
+
+        Use this when you already know the ObjectId and want to avoid the Graph API call.
+        If both -UpdateObjectId and -ObjectId are specified, the explicitly provided -ObjectId
+        value takes precedence and no Graph lookup is performed.
+
     .PARAMETER DatabaseServer
         The name of the database server
-        
+
         If on-premises or classic SQL Server, use either short name og Fully Qualified Domain Name (FQDN)
-        
+
         If Azure use the full address to the database server, e.g. server.database.windows.net
-        
+
     .PARAMETER DatabaseName
         The name of the database
-        
+
     .PARAMETER SqlUser
         The login name for the SQL Server instance
-        
+
     .PARAMETER SqlPwd
         The password for the SQL Server user
-        
+
     .EXAMPLE
         PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com"
-        
+
         This will import an user from an external Azure Active Directory.
         The new user will get the system wide Id "John".
         The name of the new user will be "John Doe".
         The e-mail address / sign-in e-mail address will be registered as "John@contoso.com".
-        
+
+    .EXAMPLE
+        PS C:\> Connect-AzAccount
+        PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -UpdateObjectId
+
+        This will import an user from an external Azure Active Directory and resolve the user's
+        ObjectId from Microsoft Graph to store in D365FO.
+
+        Connect-AzAccount is required before using -UpdateObjectId.
+
+        Resolving the ObjectId is necessary to avoid login failures in environments that have had
+        their database restored from a Tier-2 environment, where the UserInfo OBJECTID column would
+        otherwise be copied from the environment's admin user.
+
+    .EXAMPLE
+        PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -ObjectId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+        This will import an user from an external Azure Active Directory and use the supplied
+        ObjectId directly, without making a Microsoft Graph API call.
+
     .NOTES
         Tags: User, Users, Security, Configuration, Permission, AAD, Azure Active Directory
-        
+
         Author: Anderson Joyle (@AndersonJoyle)
-        
+
         Author: Mötz Jensen (@Splaxi)
 #>
 
@@ -88,6 +127,12 @@ function Import-D365ExternalUser {
 
         [Parameter(Mandatory = $false)]
         [string] $Language = "en-us",
+
+        [Parameter(Mandatory = $false)]
+        [switch] $UpdateObjectId,
+
+        [Parameter(Mandatory = $false)]
+        [string] $ObjectId,
 
         [Parameter(Mandatory = $false)]
         [string]$DatabaseServer = $Script:DatabaseServer,
@@ -125,17 +170,46 @@ function Import-D365ExternalUser {
 
     process {
         if (Test-PSFFunctionInterrupt) { return }
-        
+
         try {
             $userAuth = Get-D365UserAuthenticationDetail $Email
 
             $provider = $userAuth.IdentityProvider
             $networkDomain = $userAuth.NetworkDomain
             $sid = $userAuth.SID
-            
+
             Write-PSFMessage -Level Verbose -Message "Extracted sid: $sid"
 
-            Import-AadUserIntoD365FO -SqlCommand $SqlCommand -SignInName $Email -Name $Name -Id $Id -SID $SID -StartUpCompany $Company -IdentityProvider $provider -NetworkDomain $networkDomain -Language $Language
+            # Resolve ObjectId: caller-supplied value takes precedence; if -UpdateObjectId is set
+            # and no explicit -ObjectId was provided, look it up from Microsoft Graph.
+            $resolvedObjectId = ""
+
+            if ($PSBoundParameters.ContainsKey("ObjectId")) {
+                $resolvedObjectId = $ObjectId
+                Write-PSFMessage -Level Verbose -Message "Using caller-supplied ObjectId: $resolvedObjectId"
+            }
+            elseif ($UpdateObjectId) {
+                Write-PSFMessage -Level Verbose -Message "Looking up ObjectId for $Email from Microsoft Graph"
+
+                $resObj = Invoke-AzRestMethod -Uri "https://graph.microsoft.com/v1.0/users?`$filter=mail eq '$Email' or userPrincipalName eq '$Email'"
+
+                if ($resObj.StatusCode -like "2**") {
+                    $aadUser = $resObj.Content | ConvertFrom-Json | Select-Object -ExpandProperty value | Select-Object -First 1
+
+                    if ($null -ne $aadUser) {
+                        $resolvedObjectId = $aadUser.id
+                        Write-PSFMessage -Level Verbose -Message "Resolved ObjectId: $resolvedObjectId"
+                    }
+                    else {
+                        Write-PSFMessage -Level Warning -Message "Microsoft Graph returned no user matching '$Email'. Proceeding without ObjectId."
+                    }
+                }
+                else {
+                    Write-PSFMessage -Level Warning -Message "Microsoft Graph lookup failed for '$Email' (HTTP $($resObj.StatusCode)). Proceeding without ObjectId."
+                }
+            }
+
+            Import-AadUserIntoD365FO -SqlCommand $SqlCommand -SignInName $Email -Name $Name -Id $Id -SID $SID -StartUpCompany $Company -IdentityProvider $provider -NetworkDomain $networkDomain -Language $Language -ObjectId $resolvedObjectId
 
             if (Test-PSFFunctionInterrupt) { return }
         }

--- a/d365fo.tools/functions/import-d365externaluser.ps1
+++ b/d365fo.tools/functions/import-d365externaluser.ps1
@@ -1,110 +1,110 @@
-
+﻿
 <#
     .SYNOPSIS
         Import an user from an external Azure Active Directory (AAD)
-
+        
     .DESCRIPTION
         Imports an user from an AAD that is NOT the same as the AAD tenant that the D365FO environment is running under
-
+        
     .PARAMETER Id
         The internal Id that the user must be imported with
-
+        
         The Id has to unique across the entire user base
-
+        
     .PARAMETER Name
         The display name of the user inside the D365FO environment
-
+        
     .PARAMETER Email
         The email address of the user that you want to import
-
+        
         This is also the sign-in user name / e-mail address to gain access to the system
-
+        
         If the external AAD tenant has multiple custom domain names, you have to use the domain that they have configured as default
-
+        
     .PARAMETER Company
         Default company that should be configured for the user, for when they sign-in to the D365 environment
-
+        
         Default value is "DAT"
-
+        
     .PARAMETER Language
         Language that should be configured for the user, for when they sign-in to the D365 environment
-
+        
         Default value is "en-US"
-
+        
     .PARAMETER Enabled
         Should the imported user be enabled or not?
-
+        
         Default value is 1, which equals true / yes
-
+        
     .PARAMETER UpdateObjectId
         Switch to look up the user's Azure AD ObjectId from Microsoft Graph and store it in D365FO.
-
+        
         When this switch is enabled, the cmdlet calls Microsoft Graph
         (https://graph.microsoft.com/v1.0/users) to resolve the ObjectId for the given Email address
         and passes it to the underlying SQL import. This fixes a known issue where restoring a
         Tier-2 database to a Tier-1 environment causes user sign-in failures because the UserInfo
         table's OBJECTID column is incorrectly copied from the admin user.
-
+        
         Requires an active Azure connection (Connect-AzAccount) before calling this cmdlet.
-
+        
         Without this switch, ObjectId is left empty and existing behavior is preserved.
-
+        
     .PARAMETER ObjectId
         Explicitly provide the Azure AD ObjectId for the user being imported.
-
+        
         Use this when you already know the ObjectId and want to avoid the Graph API call.
         If both -UpdateObjectId and -ObjectId are specified, the explicitly provided -ObjectId
         value takes precedence and no Graph lookup is performed.
-
+        
     .PARAMETER DatabaseServer
         The name of the database server
-
+        
         If on-premises or classic SQL Server, use either short name og Fully Qualified Domain Name (FQDN)
-
+        
         If Azure use the full address to the database server, e.g. server.database.windows.net
-
+        
     .PARAMETER DatabaseName
         The name of the database
-
+        
     .PARAMETER SqlUser
         The login name for the SQL Server instance
-
+        
     .PARAMETER SqlPwd
         The password for the SQL Server user
-
+        
     .EXAMPLE
         PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com"
-
+        
         This will import an user from an external Azure Active Directory.
         The new user will get the system wide Id "John".
         The name of the new user will be "John Doe".
         The e-mail address / sign-in e-mail address will be registered as "John@contoso.com".
-
+        
     .EXAMPLE
         PS C:\> Connect-AzAccount
         PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -UpdateObjectId
-
+        
         This will import an user from an external Azure Active Directory and resolve the user's
         ObjectId from Microsoft Graph to store in D365FO.
-
+        
         Connect-AzAccount is required before using -UpdateObjectId.
-
+        
         Resolving the ObjectId is necessary to avoid login failures in environments that have had
         their database restored from a Tier-2 environment, where the UserInfo OBJECTID column would
         otherwise be copied from the environment's admin user.
-
+        
     .EXAMPLE
         PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -ObjectId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-
+        
         This will import an user from an external Azure Active Directory and use the supplied
         ObjectId directly, without making a Microsoft Graph API call.
-
+        
     .NOTES
         Tags: User, Users, Security, Configuration, Permission, AAD, Azure Active Directory
-
+        
         Author: Anderson Joyle (@AndersonJoyle)
-
-        Author: Mötz Jensen (@Splaxi)
+        
+        Author: MÃ¶tz Jensen (@Splaxi)
 #>
 
 function Import-D365ExternalUser {

--- a/d365fo.tools/functions/import-d365externaluser.ps1
+++ b/d365fo.tools/functions/import-d365externaluser.ps1
@@ -81,7 +81,6 @@
         The e-mail address / sign-in e-mail address will be registered as "John@contoso.com".
         
     .EXAMPLE
-        PS C:\> Connect-AzAccount
         PS C:\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -UpdateObjectId
         
         This will import an user from an external Azure Active Directory and resolve the user's

--- a/d365fo.tools/tests/functions/Import-D365ExternalUser.Tests.ps1
+++ b/d365fo.tools/tests/functions/Import-D365ExternalUser.Tests.ps1
@@ -89,6 +89,32 @@
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
+		It 'Should have the expected parameter UpdateObjectId' {
+			$parameter = (Get-Command Import-D365ExternalUser).Parameters['UpdateObjectId']
+			$parameter.Name | Should -Be 'UpdateObjectId'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ObjectId' {
+			$parameter = (Get-Command Import-D365ExternalUser).Parameters['ObjectId']
+			$parameter.Name | Should -Be 'ObjectId'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 6
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
 		It 'Should have the expected parameter DatabaseServer' {
 			$parameter = (Get-Command Import-D365ExternalUser).Parameters['DatabaseServer']
 			$parameter.Name | Should -Be 'DatabaseServer'
@@ -97,7 +123,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 6
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 7
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -110,7 +136,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 7
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 8
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -123,7 +149,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 8
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 9
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -136,7 +162,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 9
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 10
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -146,7 +172,7 @@
 	Describe "Testing parameterset __AllParameterSets" {
 		<#
 		__AllParameterSets -Id -Name -Email
-		__AllParameterSets -Id -Name -Email -Enabled -Company -Language -DatabaseServer -DatabaseName -SqlUser -SqlPwd
+		__AllParameterSets -Id -Name -Email -Enabled -Company -Language -UpdateObjectId -ObjectId -DatabaseServer -DatabaseName -SqlUser -SqlPwd
 		#>
 	}
 

--- a/docs/Import-D365ExternalUser.md
+++ b/docs/Import-D365ExternalUser.md
@@ -14,8 +14,9 @@ Import an user from an external Azure Active Directory (AAD)
 
 ```
 Import-D365ExternalUser [-Id] <String> [-Name] <String> [-Email] <String> [[-Enabled] <Int32>]
- [[-Company] <String>] [[-Language] <String>] [[-DatabaseServer] <String>] [[-DatabaseName] <String>]
- [[-SqlUser] <String>] [[-SqlPwd] <String>] [<CommonParameters>]
+ [[-Company] <String>] [[-Language] <String>] [-UpdateObjectId] [[-ObjectId] <String>]
+ [[-DatabaseServer] <String>] [[-DatabaseName] <String>] [[-SqlUser] <String>] [[-SqlPwd] <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,6 +33,30 @@ This will import an user from an external Azure Active Directory.
 The new user will get the system wide Id "John".
 The name of the new user will be "John Doe".
 The e-mail address / sign-in e-mail address will be registered as "John@contoso.com".
+
+### EXAMPLE 2
+```
+Connect-AzAccount
+```
+
+PS C:\\\> Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -UpdateObjectId
+
+This will import an user from an external Azure Active Directory and resolve the user's
+ObjectId from Microsoft Graph to store in D365FO.
+
+Connect-AzAccount is required before using -UpdateObjectId.
+
+Resolving the ObjectId is necessary to avoid login failures in environments that have had
+their database restored from a Tier-2 environment, where the UserInfo OBJECTID column would
+otherwise be copied from the environment's admin user.
+
+### EXAMPLE 3
+```
+Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -ObjectId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+This will import an user from an external Azure Active Directory and use the supplied
+ObjectId directly, without making a Microsoft Graph API call.
 
 ## PARAMETERS
 
@@ -137,6 +162,51 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -UpdateObjectId
+Switch to look up the user's Azure AD ObjectId from Microsoft Graph and store it in D365FO.
+
+When this switch is enabled, the cmdlet calls Microsoft Graph
+(https://graph.microsoft.com/v1.0/users) to resolve the ObjectId for the given Email address
+and passes it to the underlying SQL import.
+This fixes a known issue where restoring a
+Tier-2 database to a Tier-1 environment causes user sign-in failures because the UserInfo
+table's OBJECTID column is incorrectly copied from the admin user.
+
+Requires an active Azure connection (Connect-AzAccount) before calling this cmdlet.
+
+Without this switch, ObjectId is left empty and existing behavior is preserved.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectId
+Explicitly provide the Azure AD ObjectId for the user being imported.
+
+Use this when you already know the ObjectId and want to avoid the Graph API call.
+If both -UpdateObjectId and -ObjectId are specified, the explicitly provided -ObjectId
+value takes precedence and no Graph lookup is performed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DatabaseServer
 The name of the database server
 
@@ -151,7 +221,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 7
+Position: 8
 Default value: $Script:DatabaseServer
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -166,7 +236,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: $Script:DatabaseName
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -181,7 +251,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 10
 Default value: $Script:DatabaseUserName
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -196,7 +266,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 10
+Position: 11
 Default value: $Script:DatabaseUserPassword
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -214,6 +284,6 @@ Tags: User, Users, Security, Configuration, Permission, AAD, Azure Active Direct
 
 Author: Anderson Joyle (@AndersonJoyle)
 
-Author: Mötz Jensen (@Splaxi)
+Author: M ¶tz Jensen (@Splaxi)
 
 ## RELATED LINKS


### PR DESCRIPTION
Closes #904

## Problem

When `Import-D365ExternalUser` imports a user, it calls the internal `Import-AadUserIntoD365FO` without the `-ObjectId` parameter. The underlying SQL script (`New-D365FOUser`) copies the environment admin's `OBJECTID` into the new user's row when `ObjectId` is an empty string. This causes the new user to share the admin's Object ID, which breaks sign-in on Tier-1 environments after a Tier-2 database restore.

## Solution

- Add `[switch] $UpdateObjectId`: when set, queries Microsoft Graph (`/v1.0/users?$filter=mail eq '...' or userPrincipalName eq '...'`) to resolve the user's Azure AD Object ID and pass it to `Import-AadUserIntoD365FO`. Mirrors the Graph lookup already used in `Import-D365AadUser`.
- Add `[string] $ObjectId`: caller-supplied override; takes precedence over the Graph lookup when both params are provided.
- Without either parameter, `$resolvedObjectId = ""` — existing behavior is fully preserved (no breaking change).

Requires an active `Connect-AzAccount` session when `-UpdateObjectId` is used.

## Usage

```powershell
# New: resolve ObjectId from Graph automatically
Connect-AzAccount
Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -UpdateObjectId

# New: supply ObjectId directly (no Graph call)
Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com" -ObjectId "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

# Existing: unchanged behavior
Import-D365ExternalUser -Id "John" -Name "John Doe" -Email "John@contoso.com"
```