### PR TITLE
Include extension fields in Invoke-D365GenerateReportDataEntity (#649)

### DIFF
--- a/d365fo.tools/functions/invoke-d365generatereportdataentity.ps1
+++ b/d365fo.tools/functions/invoke-d365generatereportdataentity.ps1
@@ -101,7 +101,7 @@ function Invoke-D365GenerateReportDataEntity {
 
             Write-PSFMessage -Level Verbose -Message "Working on: $elementName (DataEntity)" -Target $elementName
             
-            $element = $metadataProvider.DataEntityViews.Read($elementName)
+            $element = [Microsoft.Dynamics.AX.Metadata.Storage.Extension.ExtensionMethods]::ReadDataEntityViewWithExtensions($metadataProvider, $elementName, $null, $null)
 
             #filter out system fields
             $fields = @()


### PR DESCRIPTION
## What this does

`Invoke-D365GenerateReportDataEntity` reflects over data entities with the metadata disk provider and lists their fields, but it currently omits any fields added to an entity through **extensions**.

This switches the entity read from `DataEntityViews.Read(...)` to `ExtensionMethods.ReadDataEntityViewWithExtensions(...)`, so the generated report includes extension fields as well.

## Why

Closes #649. Full credit to @FH-Inway, who investigated the (undocumented) metadata API, identified the exact fix, and confirmed a working version in the issue thread.

## Change

In `invoke-d365generatereportdataentity.ps1`:

```powershell
# before
$element = $metadataProvider.DataEntityViews.Read($elementName)
# after
$element = [Microsoft.Dynamics.AX.Metadata.Storage.Extension.ExtensionMethods]::ReadDataEntityViewWithExtensions($metadataProvider, $elementName, $null, $null)
```

`ExtensionMethods` lives in the same `Microsoft.Dynamics.AX.Metadata.Storage` assembly that is already loaded via `Import-GenerateReportAssemblies` (and used for `MetadataProviderFactory`), so no new dependency is introduced. The disk provider is still used, so the cmdlet continues to run against uncompiled sources.

## Follow-up

As @FH-Inway noted, `Invoke-D365GenerateReportDataEntityField` (via the internal `Get-AXDataEntities`) likely needs the same treatment. Happy to address that in a separate, focused PR.