### PR TITLE
Fix Restart-D365Environment -Kill error; use ConvertTo-PSFHashtable (…

### DIFF
--- a/d365fo.tools/functions/restart-d365environment.ps1
+++ b/d365fo.tools/functions/restart-d365environment.ps1
@@ -111,8 +111,7 @@ function Restart-D365Environment {
 
     Stop-D365Environment @PSBoundParameters | Format-Table
     
-    $parms = Get-DeepClone $PSBoundParameters
-    if ($parms.ContainsKey("Kill")) { $null = $Params.Remove("Kill") }
+    $parms = $PSBoundParameters | ConvertTo-PSFHashtable -ReferenceCommand Start-D365Environment
 
     Start-D365Environment @parms | Format-Table
 }


### PR DESCRIPTION
## The bug

`Restart-D365Environment -Kill` (a documented example in the cmdlet's own help) currently fails. The code was:

```powershell
$parms = Get-DeepClone $PSBoundParameters
if ($parms.ContainsKey("Kill")) { $null = $Params.Remove("Kill") }
Start-D365Environment @parms | Format-Table
```

The intent is to strip `Kill` before calling `Start-D365Environment` (which has no `-Kill` parameter), but the removal targets the undefined variable `$Params` instead of `$parms`. So when `-Kill` is supplied, the line throws *"You cannot call a method on a null-valued expression"* — and `Kill` is never actually removed.

## The fix

Replace the manual clone + remove with `ConvertTo-PSFHashtable -ReferenceCommand Start-D365Environment`, which keeps only the parameters `Start-D365Environment` actually accepts, so `Kill` is dropped correctly and the typo is gone:

```powershell
$parms = $PSBoundParameters | ConvertTo-PSFHashtable -ReferenceCommand Start-D365Environment
Start-D365Environment @parms | Format-Table
```

The preceding `Stop-D365Environment @PSBoundParameters` call is unchanged (it does accept `-Kill`).

This also applies the PSFramework splatting quick-win from #870 (suggested by @FriedrichWeinmann). `ConvertTo-PSFHashtable -ReferenceCommand` is available in the module's minimum required PSFramework version (1.9.308), so no dependency bump is needed.

Refs #870