### PR TITLE
Replace [string]::IsNullOrEmpty with -not in Azure storage cmdlets (#870)

### DIFF
--- a/d365fo.tools/functions/get-d365azurestoragefile.ps1
+++ b/d365fo.tools/functions/get-d365azurestoragefile.ps1
@@ -90,7 +90,7 @@ function Get-D365AzureStorageFile {
 
     Invoke-TimeSignal -Start
 
-    if ([string]::IsNullOrEmpty($SAS)) {
+    if (-not $SAS) {
         Write-PSFMessage -Level Verbose -Message "Working against Azure Storage Account with AccessToken"
 
         $storageContext = New-AzStorageContext -StorageAccountName $AccountId.ToLower() -StorageAccountKey $AccessToken

--- a/d365fo.tools/functions/get-d365azurestorageurl.ps1
+++ b/d365fo.tools/functions/get-d365azurestorageurl.ps1
@@ -71,9 +71,9 @@ function Get-D365AzureStorageUrl {
         [switch] $OutputAsHashtable
     )
 
-    if (([string]::IsNullOrEmpty($AccountId) -eq $true) -or
-        ([string]::IsNullOrEmpty($Container)) -or
-        ([string]::IsNullOrEmpty($SAS))) {
+    if ((-not $AccountId) -or
+        (-not $Container) -or
+        (-not $SAS)) {
         Write-PSFMessage -Level Host -Message "It seems that you are missing some of the parameters. Please make sure that you either supplied them or have the right configuration saved."
         Stop-PSFFunction -Message "Stopping because of missing parameters"
         return

--- a/d365fo.tools/functions/invoke-d365azurestoragedownload.ps1
+++ b/d365fo.tools/functions/invoke-d365azurestoragedownload.ps1
@@ -114,9 +114,9 @@ function Invoke-D365AzureStorageDownload {
             return
         }
 
-        if (([string]::IsNullOrEmpty($AccountId) -eq $true) -or
-            ([string]::IsNullOrEmpty($Container)) -or
-            (([string]::IsNullOrEmpty($AccessToken)) -and ([string]::IsNullOrEmpty($SAS)))) {
+        if ((-not $AccountId) -or
+            (-not $Container) -or
+            ((-not $AccessToken) -and (-not $SAS))) {
             Write-PSFMessage -Level Host -Message "It seems that you are missing some of the parameters. Please make sure that you either supplied them or have the right configuration saved."
             Stop-PSFFunction -Message "Stopping because of missing parameters"
             return
@@ -129,7 +129,7 @@ function Invoke-D365AzureStorageDownload {
 
         try {
 
-            if ([string]::IsNullOrEmpty($SAS)) {
+            if (-not $SAS) {
                 Write-PSFMessage -Level Verbose -Message "Working against Azure Storage Account with AccessToken"
 
                 $storageContext = New-AzStorageContext -StorageAccountName $AccountId.ToLower() -StorageAccountKey $AccessToken

--- a/d365fo.tools/functions/invoke-d365azurestorageupload.ps1
+++ b/d365fo.tools/functions/invoke-d365azurestorageupload.ps1
@@ -105,9 +105,9 @@ function Invoke-D365AzureStorageUpload {
         [switch] $EnableException
     )
     BEGIN {
-        if (([string]::IsNullOrEmpty($AccountId) -eq $true) -or
-            ([string]::IsNullOrEmpty($Container)) -or
-            (([string]::IsNullOrEmpty($AccessToken)) -and ([string]::IsNullOrEmpty($SAS)))) {
+        if ((-not $AccountId) -or
+            (-not $Container) -or
+            ((-not $AccessToken) -and (-not $SAS))) {
             Write-PSFMessage -Level Host -Message "It seems that you are missing some of the parameters. Please make sure that you either supplied them or have the right configuration saved."
             Stop-PSFFunction -Message "Stopping because of missing parameters"
             return
@@ -121,7 +121,7 @@ function Invoke-D365AzureStorageUpload {
         $FileName = Split-Path -Path $Filepath -Leaf
         try {
 
-            if ([string]::IsNullOrEmpty($SAS)) {
+            if (-not $SAS) {
                 Write-PSFMessage -Level Verbose -Message "Working against Azure Storage Account with AccessToken"
 
                 $storageContext = New-AzStorageContext -StorageAccountName $AccountId.ToLower() -StorageAccountKey $AccessToken
@@ -136,7 +136,7 @@ function Invoke-D365AzureStorageUpload {
 
             Write-PSFMessage -Level Verbose -Message "Start uploading the file to Azure"
 
-            if ([string]::IsNullOrEmpty($ContentType)) {
+            if (-not $ContentType) {
                 $ContentType = [System.Web.MimeMapping]::GetMimeMapping($Filepath) # Available since .NET4.5, so it can be used with PowerShell 5.0 and higher.
 
                 Write-PSFMessage -Level Verbose -Message "Content Type is automatically set to value: $ContentType"


### PR DESCRIPTION
Applies the **`[string]::IsNullOrEmpty` → `-not`** quick-win from #870 (suggested by @FriedrichWeinmann) to the Azure storage cmdlets.

For a string operand, `[string]::IsNullOrEmpty($x)` is equivalent to `-not $x`, so this replaces the more verbose form:

```powershell
# before
if (([string]::IsNullOrEmpty($AccountId) -eq $true) -or
    ([string]::IsNullOrEmpty($Container)) -or
    (([string]::IsNullOrEmpty($AccessToken)) -and ([string]::IsNullOrEmpty($SAS)))) {

# after
if ((-not $AccountId) -or
    (-not $Container) -or
    ((-not $AccessToken) -and (-not $SAS))) {
```

### Files
- `Get-D365AzureStorageFile`
- `Get-D365AzureStorageUrl`
- `Invoke-D365AzureStorageDownload`
- `Invoke-D365AzureStorageUpload`

### Notes
- Every operand here is a `[string]` parameter, so `-not` and `[string]::IsNullOrEmpty` are equivalent — they only differ for non-string values such as `0` or `$false`. I kept the original parentheses/grouping so the boolean logic is unchanged.
- **Scope:** limited to the Azure storage cmdlets @FriedrichWeinmann referenced. The same simplification applies to other string-parameter checks across the module — happy to follow up in a separate PR. I intentionally left sites where the operand is an object or external-command output (e.g. `Get-MpComputerStatus`, `& $executable ...`) unchanged, since `-not` is not equivalent there.

Refs #870