### PR TITLE
fix: include extension fields in Invoke-D365GenerateReportDataEntityField (#649 follow-up)

### DIFF
--- a/d365fo.tools/internal/functions/get-axdataentities.ps1
+++ b/d365fo.tools/internal/functions/get-axdataentities.ps1
@@ -77,7 +77,7 @@ Function Get-AxDataEntities {
         foreach ($tuple in $dataEntityModelInfos) {
             $elementName = $tuple.Item1
 
-            $element = $metadataProvider.DataEntityViews.Read($elementName)
+            $element = [Microsoft.Dynamics.AX.Metadata.Storage.Extension.ExtensionMethods]::ReadDataEntityViewWithExtensions($metadataProvider, $elementName, $null, $null)
 
             #
             # Build list of DataSources


### PR DESCRIPTION
Follow-up to #910 (issue #649), per @FH-Inway's request to also cover Invoke-D365GenerateReportDataEntityField / Get-AxDataEntities.

Invoke-D365GenerateReportDataEntityField builds its report through the internal Get-AxDataEntities, which still read each entity with DataEntityViews.Read($elementName), so fields added to an entity via extensions were omitted from the field-level report. This applies the same fix #910 made to Invoke-D365GenerateReportDataEntity, switching the read to the extension-aware ReadDataEntityViewWithExtensions call.

ExtensionMethods lives in the Microsoft.Dynamics.AX.Metadata.Storage assembly already loaded by Import-GenerateReportAssemblies, so no new dependency is introduced. This is an internal-helper change only, with no public parameter or help changes. (The diff also normalizes a missing end-of-file newline that the web editor added automatically.)

Refs #649, #910